### PR TITLE
feat: core modules — GitHub client, parser, graph engine, visual system

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,107 @@
 import { HashRouter, Routes, Route } from 'react-router-dom';
+import { useKnowledgeBase } from './hooks/useKnowledgeBase';
+import './styles/visuals.css';
+
+function LoadingScreen() {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      height: '100vh', flexDirection: 'column', gap: '16px',
+    }}>
+      <div style={{
+        width: 40, height: 40, border: '3px solid var(--border)',
+        borderTopColor: 'var(--accent)', borderRadius: '50%',
+        animation: 'spin 0.8s linear infinite',
+      }} />
+      <p style={{ color: 'var(--fg-muted)', fontFamily: 'var(--font-body)' }}>
+        Loading knowledge base…
+      </p>
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+}
+
+function ErrorScreen({ message }: { message: string }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      height: '100vh', flexDirection: 'column', gap: '12px', padding: '2rem',
+    }}>
+      <span style={{ fontSize: 48 }}>⚠️</span>
+      <h1 style={{ fontFamily: 'var(--font-heading)', fontSize: '1.5rem' }}>
+        Failed to load
+      </h1>
+      <p style={{ color: 'var(--fg-muted)', maxWidth: 500, textAlign: 'center' }}>
+        {message}
+      </p>
+    </div>
+  );
+}
+
+function Explorer() {
+  const state = useKnowledgeBase();
+
+  if (state.status === 'loading') return <LoadingScreen />;
+  if (state.status === 'error') return <ErrorScreen message={state.error} />;
+
+  const { graph, config } = state;
+
+  return (
+    <Routes>
+      <Route path="/" element={
+        <div style={{ padding: '2rem' }}>
+          <h1 style={{ fontFamily: 'var(--font-heading)', marginBottom: '0.5rem' }}>
+            {config.title}
+          </h1>
+          {config.subtitle && (
+            <p style={{ color: 'var(--fg-muted)', marginBottom: '2rem' }}>
+              {config.subtitle}
+            </p>
+          )}
+          <p style={{ color: 'var(--fg-muted)' }}>
+            {graph.nodes.length} nodes · {graph.edges.length} edges · {graph.clusters.length} clusters
+          </p>
+          <div style={{ marginTop: '2rem', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+            {graph.nodes.slice(0, 20).map(node => (
+              <a
+                key={node.id}
+                href={`#/node/${encodeURIComponent(node.id)}`}
+                style={{
+                  display: 'flex', alignItems: 'center', gap: '12px',
+                  padding: '12px 16px',
+                  background: 'rgba(255,255,255,0.03)',
+                  borderRadius: '8px', border: '1px solid var(--border)',
+                }}
+              >
+                <span style={{ fontSize: 20 }}>{node.emoji ?? '📌'}</span>
+                <span>{node.title}</span>
+                <span style={{ color: 'var(--fg-muted)', fontSize: '0.85rem', marginLeft: 'auto' }}>
+                  {node.cluster}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      } />
+      <Route path="/graph" element={
+        <div style={{ padding: '2rem' }}>
+          <h1 style={{ fontFamily: 'var(--font-heading)' }}>Constellation</h1>
+          <p style={{ color: 'var(--fg-muted)' }}>Graph view — coming next</p>
+        </div>
+      } />
+      <Route path="/node/:id" element={
+        <div style={{ padding: '2rem' }}>
+          <p style={{ color: 'var(--fg-muted)' }}>Reading view — coming next</p>
+        </div>
+      } />
+    </Routes>
+  );
+}
 
 function App() {
   return (
     <HashRouter>
-      <Routes>
-        <Route path="/" element={<div>Overview</div>} />
-        <Route path="/graph" element={<div>Graph</div>} />
-        <Route path="/node/:id" element={<div>Reading</div>} />
-      </Routes>
+      <Explorer />
     </HashRouter>
   );
 }

--- a/src/api/github.ts
+++ b/src/api/github.ts
@@ -1,0 +1,223 @@
+/**
+ * GitHub API client for fetching repository content at runtime.
+ * Supports two modes:
+ *   - authored: fetches markdown files from a content directory
+ *   - repo-aware: fetches issues, PRs, README, and file tree
+ */
+import type { SourceConfig } from '../types';
+
+const CACHE_PREFIX = 'kbe:';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+interface CacheEntry<T> {
+  data: T;
+  etag?: string;
+  ts: number;
+}
+
+function cacheGet<T>(key: string): CacheEntry<T> | null {
+  try {
+    const raw = localStorage.getItem(CACHE_PREFIX + key);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as CacheEntry<T>;
+    if (Date.now() - entry.ts > CACHE_TTL_MS) {
+      localStorage.removeItem(CACHE_PREFIX + key);
+      return null;
+    }
+    return entry;
+  } catch {
+    return null;
+  }
+}
+
+function cacheSet<T>(key: string, data: T, etag?: string): void {
+  try {
+    const entry: CacheEntry<T> = { data, etag, ts: Date.now() };
+    localStorage.setItem(CACHE_PREFIX + key, JSON.stringify(entry));
+  } catch {
+    // localStorage full or unavailable — skip silently
+  }
+}
+
+async function ghFetch<T>(path: string, etag?: string): Promise<{ data: T; etag?: string }> {
+  const headers: Record<string, string> = {
+    Accept: 'application/vnd.github.v3+json',
+  };
+  if (etag) {
+    headers['If-None-Match'] = etag;
+  }
+
+  const res = await fetch(`https://api.github.com${path}`, { headers });
+
+  if (res.status === 304) {
+    throw new NotModifiedError();
+  }
+  if (res.status === 403 && res.headers.get('X-RateLimit-Remaining') === '0') {
+    const reset = res.headers.get('X-RateLimit-Reset');
+    throw new RateLimitError(reset ? new Date(Number(reset) * 1000) : undefined);
+  }
+  if (!res.ok) {
+    throw new GitHubApiError(res.status, await res.text());
+  }
+
+  return {
+    data: (await res.json()) as T,
+    etag: res.headers.get('ETag') ?? undefined,
+  };
+}
+
+export class NotModifiedError extends Error {
+  constructor() { super('Not modified'); this.name = 'NotModifiedError'; }
+}
+
+export class RateLimitError extends Error {
+  resetAt?: Date;
+  constructor(resetAt?: Date) {
+    super(`GitHub API rate limit exceeded${resetAt ? `. Resets at ${resetAt.toISOString()}` : ''}`);
+    this.name = 'RateLimitError';
+    this.resetAt = resetAt;
+  }
+}
+
+export class GitHubApiError extends Error {
+  status: number;
+  constructor(status: number, body: string) {
+    super(`GitHub API error ${status}: ${body}`);
+    this.name = 'GitHubApiError';
+    this.status = status;
+  }
+}
+
+// ── GitHub API response types ──────────────────────────────
+
+export interface GHTreeItem {
+  path: string;
+  mode: string;
+  type: 'blob' | 'tree';
+  sha: string;
+  size?: number;
+  url: string;
+}
+
+export interface GHIssue {
+  number: number;
+  title: string;
+  body: string | null;
+  state: string;
+  labels: Array<{ name: string; color: string }>;
+  assignees: Array<{ login: string }>;
+  html_url: string;
+  created_at: string;
+  updated_at: string;
+  pull_request?: { url: string };
+}
+
+export interface GHFileContent {
+  name: string;
+  path: string;
+  sha: string;
+  content: string; // base64 encoded
+  encoding: string;
+}
+
+// ── Public API ─────────────────────────────────────────────
+
+/** Resolve an image path to a raw.githubusercontent.com URL. */
+export function resolveImageUrl(source: SourceConfig, path: string): string {
+  const branch = source.branch ?? 'main';
+  return `https://raw.githubusercontent.com/${source.owner}/${source.repo}/${branch}/${path}`;
+}
+
+/** Fetch and decode a single file from the repo. */
+export async function fetchFile(source: SourceConfig, path: string): Promise<string> {
+  const cacheKey = `file:${source.owner}/${source.repo}:${path}`;
+  const cached = cacheGet<string>(cacheKey);
+  if (cached) return cached.data;
+
+  const branch = source.branch ?? 'main';
+  const { data } = await ghFetch<GHFileContent>(
+    `/repos/${source.owner}/${source.repo}/contents/${path}?ref=${branch}`
+  );
+
+  const decoded = atob(data.content);
+  cacheSet(cacheKey, decoded, data.sha);
+  return decoded;
+}
+
+/** List all files in a directory (recursive via Git Trees API). */
+export async function fetchTree(source: SourceConfig, path?: string): Promise<GHTreeItem[]> {
+  const cacheKey = `tree:${source.owner}/${source.repo}:${path ?? ''}`;
+  const cached = cacheGet<GHTreeItem[]>(cacheKey);
+  if (cached) return cached.data;
+
+  const branch = source.branch ?? 'main';
+  const { data } = await ghFetch<{ tree: GHTreeItem[] }>(
+    `/repos/${source.owner}/${source.repo}/git/trees/${branch}?recursive=1`
+  );
+
+  const items = path
+    ? data.tree.filter(item => item.path.startsWith(path + '/'))
+    : data.tree;
+
+  cacheSet(cacheKey, items);
+  return items;
+}
+
+/** Fetch issues (not PRs) from the repo. */
+export async function fetchIssues(source: SourceConfig): Promise<GHIssue[]> {
+  const cacheKey = `issues:${source.owner}/${source.repo}`;
+  const cached = cacheGet<GHIssue[]>(cacheKey);
+  if (cached) return cached.data;
+
+  const allIssues: GHIssue[] = [];
+  let page = 1;
+  const perPage = 100;
+
+  while (true) {
+    const { data } = await ghFetch<GHIssue[]>(
+      `/repos/${source.owner}/${source.repo}/issues?state=all&per_page=${perPage}&page=${page}`
+    );
+    // Filter out PRs (GitHub API includes PRs in issues endpoint)
+    const issues = data.filter(i => !i.pull_request);
+    allIssues.push(...issues);
+    if (data.length < perPage) break;
+    page++;
+  }
+
+  cacheSet(cacheKey, allIssues);
+  return allIssues;
+}
+
+/** Fetch pull requests from the repo. */
+export async function fetchPullRequests(source: SourceConfig): Promise<GHIssue[]> {
+  const cacheKey = `prs:${source.owner}/${source.repo}`;
+  const cached = cacheGet<GHIssue[]>(cacheKey);
+  if (cached) return cached.data;
+
+  const { data } = await ghFetch<GHIssue[]>(
+    `/repos/${source.owner}/${source.repo}/pulls?state=all&per_page=100`
+  );
+
+  cacheSet(cacheKey, data);
+  return data;
+}
+
+/** Fetch multiple files in parallel. */
+export async function fetchFiles(
+  source: SourceConfig,
+  paths: string[]
+): Promise<Map<string, string>> {
+  const results = new Map<string, string>();
+  const settled = await Promise.allSettled(
+    paths.map(async path => {
+      const content = await fetchFile(source, path);
+      return { path, content };
+    })
+  );
+  for (const result of settled) {
+    if (result.status === 'fulfilled') {
+      results.set(result.value.path, result.value.content);
+    }
+  }
+  return results;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,13 @@
+export {
+  resolveImageUrl,
+  fetchFile,
+  fetchTree,
+  fetchFiles,
+  fetchIssues,
+  fetchPullRequests,
+  NotModifiedError,
+  RateLimitError,
+  GitHubApiError,
+} from './github';
+
+export type { GHTreeItem, GHIssue, GHFileContent } from './github';

--- a/src/components/NodeVisual.tsx
+++ b/src/components/NodeVisual.tsx
@@ -1,0 +1,176 @@
+/**
+ * Visual identity system — renders node visuals across 7 surfaces × 4 modes.
+ */
+import type { KBNode, VisualMode, SourceConfig } from '../types';
+import { resolveImageUrl } from '../api';
+
+interface NodeVisualProps {
+  node: KBNode;
+  mode: VisualMode;
+  surface: 'card' | 'header' | 'hero' | 'hud-thumb' | 'hud-bg' | 'edge-preview' | 'connection';
+  source: SourceConfig;
+  className?: string;
+}
+
+const SURFACE_SIZES: Record<NodeVisualProps['surface'], { width: number; height: number }> = {
+  card: { width: 48, height: 48 },
+  header: { width: 80, height: 80 },
+  hero: { width: 0, height: 0 }, // full-width, handled by CSS
+  'hud-thumb': { width: 44, height: 44 },
+  'hud-bg': { width: 0, height: 0 }, // background, handled by CSS
+  'edge-preview': { width: 40, height: 40 },
+  connection: { width: 36, height: 36 },
+};
+
+/** Get the first letter of a title as fallback visual. */
+function firstLetter(title: string): string {
+  return title.charAt(0).toUpperCase();
+}
+
+/** Resolve the best available image URL for a node. */
+function resolveNodeImage(
+  node: KBNode,
+  mode: VisualMode,
+  source: SourceConfig
+): string | null {
+  if (mode === 'heroes' && node.image) {
+    return resolveImageUrl(source, node.image);
+  }
+  if (mode === 'sprites' && node.sprite) {
+    return resolveImageUrl(source, node.sprite);
+  }
+  return null;
+}
+
+export function NodeVisual({ node, mode, surface, source, className }: NodeVisualProps) {
+  const imageUrl = resolveNodeImage(node, mode, source);
+  const size = SURFACE_SIZES[surface];
+
+  // Hero surface — full-bleed image with gradient overlay
+  if (surface === 'hero' && mode === 'heroes' && imageUrl) {
+    return (
+      <div className={`kb-hero ${className ?? ''}`}>
+        <img
+          src={imageUrl}
+          alt={node.title}
+          className="kb-hero-img"
+          loading="eager"
+        />
+        <div className="kb-hero-overlay" />
+      </div>
+    );
+  }
+
+  // HUD background — blurred image behind HUD bar
+  if (surface === 'hud-bg' && mode === 'heroes' && imageUrl) {
+    return (
+      <div
+        className={`kb-hud-bg ${className ?? ''}`}
+        style={{ backgroundImage: `url(${imageUrl})` }}
+      />
+    );
+  }
+
+  // Image-based surfaces (card, header, hud-thumb, edge-preview, connection)
+  if (imageUrl && (mode === 'heroes' || mode === 'sprites')) {
+    const isCircular = surface === 'hud-thumb' || surface === 'edge-preview';
+    return (
+      <img
+        src={imageUrl}
+        alt={node.title}
+        width={size.width}
+        height={size.height}
+        loading="lazy"
+        className={`kb-visual kb-visual--${surface} ${isCircular ? 'kb-visual--circular' : ''} ${className ?? ''}`}
+      />
+    );
+  }
+
+  // Emoji mode
+  if (mode === 'emoji' && node.emoji) {
+    return (
+      <span
+        className={`kb-emoji kb-emoji--${surface} ${className ?? ''}`}
+        role="img"
+        aria-label={node.title}
+      >
+        {node.emoji}
+      </span>
+    );
+  }
+
+  // Fallback — first letter
+  if (mode === 'none' || !node.emoji) {
+    return (
+      <span className={`kb-letter kb-letter--${surface} ${className ?? ''}`}>
+        {firstLetter(node.title)}
+      </span>
+    );
+  }
+
+  // Emoji fallback for modes that lack an image
+  return (
+    <span
+      className={`kb-emoji kb-emoji--${surface} ${className ?? ''}`}
+      role="img"
+      aria-label={node.title}
+    >
+      {node.emoji}
+    </span>
+  );
+}
+
+/**
+ * Get vis-network node configuration for a node based on visual mode.
+ * Used by the graph view to configure node appearance.
+ */
+export function getVisNodeConfig(
+  node: KBNode,
+  mode: VisualMode,
+  source: SourceConfig,
+  clusterColor: string,
+  nodeSize: number
+): Record<string, unknown> {
+  const imageUrl = resolveNodeImage(node, mode, source);
+
+  if (mode === 'heroes' && imageUrl) {
+    return {
+      shape: 'circularImage',
+      image: imageUrl,
+      size: nodeSize,
+      borderWidth: 2.5,
+      color: {
+        border: clusterColor,
+        highlight: { border: '#E8C350' },
+        hover: { border: '#E8C350' },
+      },
+      shadow: {
+        enabled: true,
+        color: clusterColor + '33',
+        size: 18,
+        x: 0,
+        y: 0,
+      },
+    };
+  }
+
+  // Dots for sprites, emoji, none
+  return {
+    shape: 'dot',
+    size: nodeSize,
+    color: {
+      background: clusterColor + '88',
+      border: clusterColor,
+      highlight: { background: clusterColor + 'AA', border: clusterColor },
+      hover: { background: clusterColor + '99', border: clusterColor },
+    },
+    borderWidth: 2,
+    shadow: {
+      enabled: true,
+      color: clusterColor + '33',
+      size: 12,
+      x: 0,
+      y: 0,
+    },
+  };
+}

--- a/src/engine/graph.ts
+++ b/src/engine/graph.ts
@@ -1,0 +1,112 @@
+/**
+ * Graph engine: computes the knowledge graph from parsed nodes.
+ * Builds edges, clusters, related nodes, and layout positions.
+ */
+import type { KBNode, KBGraph, KBEdge, Cluster } from '../types';
+
+/** Build the full knowledge graph from a list of nodes and cluster definitions. */
+export function buildGraph(nodes: KBNode[], clusters: Cluster[]): KBGraph {
+  const nodeMap = new Map(nodes.map(n => [n.id, n]));
+  const edges = buildEdges(nodes, nodeMap);
+  const related = computeRelated(nodes, edges);
+
+  return { nodes, edges, clusters, related };
+}
+
+/** Build edges from node connections + parent/child links. */
+function buildEdges(
+  nodes: KBNode[],
+  nodeMap: Map<string, KBNode>
+): KBEdge[] {
+  const edgeSet = new Map<string, KBEdge>();
+
+  for (const node of nodes) {
+    // Explicit connections from frontmatter / cross-references
+    for (const conn of node.connections) {
+      if (nodeMap.has(conn.to)) {
+        const key = edgeKey(node.id, conn.to);
+        if (!edgeSet.has(key)) {
+          edgeSet.set(key, {
+            from: node.id,
+            to: conn.to,
+            description: conn.description,
+          });
+        }
+      }
+    }
+
+    // Parent → child edges
+    if (node.parent && nodeMap.has(node.parent)) {
+      const key = edgeKey(node.parent, node.id);
+      if (!edgeSet.has(key)) {
+        edgeSet.set(key, {
+          from: node.parent,
+          to: node.id,
+          description: 'Contains',
+        });
+      }
+    }
+  }
+
+  return [...edgeSet.values()];
+}
+
+/** Canonical edge key for deduplication. */
+function edgeKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+/** Compute related nodes for each node (neighbors sorted by degree, max 8). */
+function computeRelated(
+  nodes: KBNode[],
+  edges: KBEdge[]
+): Record<string, string[]> {
+  // Build adjacency list
+  const adj = new Map<string, Set<string>>();
+  for (const node of nodes) {
+    adj.set(node.id, new Set());
+  }
+  for (const edge of edges) {
+    adj.get(edge.from)?.add(edge.to);
+    adj.get(edge.to)?.add(edge.from);
+  }
+
+  // Degree map for sorting
+  const degree = new Map<string, number>();
+  for (const [id, neighbors] of adj) {
+    degree.set(id, neighbors.size);
+  }
+
+  const related: Record<string, string[]> = {};
+  for (const [id, neighbors] of adj) {
+    related[id] = [...neighbors]
+      .sort((a, b) => (degree.get(b) ?? 0) - (degree.get(a) ?? 0))
+      .slice(0, 8);
+  }
+
+  return related;
+}
+
+/** Get the degree (connection count) of each node. */
+export function getNodeDegrees(graph: KBGraph): Map<string, number> {
+  const degrees = new Map<string, number>();
+  for (const node of graph.nodes) {
+    degrees.set(node.id, 0);
+  }
+  for (const edge of graph.edges) {
+    degrees.set(edge.from, (degrees.get(edge.from) ?? 0) + 1);
+    degrees.set(edge.to, (degrees.get(edge.to) ?? 0) + 1);
+  }
+  return degrees;
+}
+
+/** Find the edge description between two nodes. */
+export function getEdgeDescription(
+  graph: KBGraph,
+  from: string,
+  to: string
+): string | undefined {
+  return graph.edges.find(
+    e => (e.from === from && e.to === to) || (e.from === to && e.to === from)
+  )?.description;
+}

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,0 +1,7 @@
+export { buildGraph, getNodeDegrees, getEdgeDescription } from './graph';
+export {
+  loadAuthoredContent,
+  loadRepoContent,
+  extractClusters,
+  loadConfig,
+} from './parser';

--- a/src/engine/parser.ts
+++ b/src/engine/parser.ts
@@ -1,0 +1,281 @@
+/**
+ * Content parser: transforms raw GitHub data into KBNode[] for the graph engine.
+ *
+ * Two modes:
+ *   - authored: parses markdown files with YAML frontmatter
+ *   - repo-aware: maps GitHub issues, PRs, README, and file tree to nodes
+ */
+import matter from 'gray-matter';
+import { marked } from 'marked';
+import type {
+  KBNode,
+  KBConfig,
+  Cluster,
+  SourceConfig,
+} from '../types';
+import { DEFAULT_CONFIG } from '../types';
+import {
+  fetchFile,
+  fetchTree,
+  fetchFiles,
+  fetchIssues,
+  fetchPullRequests,
+  type GHIssue,
+  type GHTreeItem,
+} from '../api';
+
+// ── Authored mode ──────────────────────────────────────────
+
+interface AuthoredFrontmatter {
+  id: string;
+  title: string;
+  emoji?: string;
+  cluster: string;
+  image?: string;
+  sprite?: string;
+  parent?: string;
+  connections?: Array<{ to: string; description: string }>;
+}
+
+function parseMarkdownFile(path: string, raw: string): KBNode {
+  const { data, content } = matter(raw);
+  const fm = data as Partial<AuthoredFrontmatter>;
+
+  const id = fm.id ?? path.replace(/\.md$/, '').replace(/.*\//, '');
+  const html = marked.parse(content, { async: false }) as string;
+
+  return {
+    id,
+    title: fm.title ?? id,
+    cluster: fm.cluster ?? 'default',
+    content: html,
+    rawContent: content,
+    emoji: fm.emoji,
+    image: fm.image,
+    sprite: fm.sprite,
+    parent: fm.parent,
+    connections: (fm.connections ?? []).map(c => ({
+      to: c.to,
+      description: c.description ?? '',
+    })),
+    source: { type: 'authored', file: path },
+  };
+}
+
+/** Load authored content from a content directory in the repo. */
+export async function loadAuthoredContent(
+  source: SourceConfig,
+  contentPath: string
+): Promise<KBNode[]> {
+  const tree = await fetchTree(source, contentPath);
+  const mdFiles = tree
+    .filter(item => item.type === 'blob' && item.path.endsWith('.md'))
+    .map(item => item.path);
+
+  const files = await fetchFiles(source, mdFiles);
+  const nodes: KBNode[] = [];
+
+  for (const [path, content] of files) {
+    try {
+      nodes.push(parseMarkdownFile(path, content));
+    } catch {
+      console.warn(`[kbexplorer] Failed to parse ${path}, skipping`);
+    }
+  }
+
+  return nodes;
+}
+
+// ── Repo-aware mode ────────────────────────────────────────
+
+/** Emoji mapping for issue types / labels. */
+const ISSUE_TYPE_EMOJI: Record<string, string> = {
+  epic: '🏔️',
+  feature: '✨',
+  task: '🔧',
+  bug: '🐛',
+  enhancement: '💡',
+  documentation: '📖',
+  question: '❓',
+};
+
+function issueEmoji(labels: string[]): string {
+  for (const label of labels) {
+    const lower = label.toLowerCase();
+    if (ISSUE_TYPE_EMOJI[lower]) return ISSUE_TYPE_EMOJI[lower];
+  }
+  return '📌';
+}
+
+/** Extract issue cross-references (#N) from body text. */
+function extractIssueRefs(body: string | null): number[] {
+  if (!body) return [];
+  const matches = body.matchAll(/#(\d+)/g);
+  return [...matches].map(m => Number(m[1]));
+}
+
+function issueToNode(issue: GHIssue): KBNode {
+  const labels = issue.labels.map(l => l.name);
+  const cluster = labels[0]?.toLowerCase() ?? 'uncategorized';
+  const body = issue.body ?? '';
+  const html = marked.parse(body, { async: false }) as string;
+  const refs = extractIssueRefs(body);
+
+  return {
+    id: `issue-${issue.number}`,
+    title: issue.title,
+    cluster,
+    content: html,
+    rawContent: body,
+    emoji: issueEmoji(labels),
+    connections: refs.map(n => ({
+      to: `issue-${n}`,
+      description: `References #${n}`,
+    })),
+    source: { type: 'issue', number: issue.number, state: issue.state, labels },
+  };
+}
+
+function prToNode(pr: GHIssue): KBNode {
+  const body = pr.body ?? '';
+  const html = marked.parse(body, { async: false }) as string;
+  const refs = extractIssueRefs(body);
+
+  return {
+    id: `pr-${pr.number}`,
+    title: pr.title,
+    cluster: 'pull-request',
+    content: html,
+    rawContent: body,
+    emoji: pr.state === 'open' ? '🟢' : '🟣',
+    connections: refs.map(n => ({
+      to: `issue-${n}`,
+      description: `Addresses #${n}`,
+    })),
+    source: { type: 'pull_request', number: pr.number, state: pr.state },
+  };
+}
+
+function readmeToNode(content: string): KBNode {
+  const html = marked.parse(content, { async: false }) as string;
+  return {
+    id: 'readme',
+    title: 'README',
+    cluster: 'docs',
+    content: html,
+    rawContent: content,
+    emoji: '📖',
+    connections: [],
+    source: { type: 'readme' },
+  };
+}
+
+/** Group tree items into top-level directory nodes. */
+function treeToNodes(tree: GHTreeItem[]): KBNode[] {
+  const topDirs = new Set<string>();
+  for (const item of tree) {
+    const parts = item.path.split('/');
+    if (parts.length > 1 && !parts[0].startsWith('.')) {
+      topDirs.add(parts[0]);
+    }
+  }
+
+  return [...topDirs].map(dir => {
+    const files = tree.filter(
+      i => i.path.startsWith(dir + '/') && i.type === 'blob'
+    );
+    const fileList = files
+      .slice(0, 20)
+      .map(f => `- \`${f.path}\``)
+      .join('\n');
+    const content = `## ${dir}/\n\n${files.length} files\n\n${fileList}`;
+    const html = marked.parse(content, { async: false }) as string;
+
+    return {
+      id: `dir-${dir}`,
+      title: `${dir}/`,
+      cluster: 'code',
+      content: html,
+      rawContent: content,
+      emoji: '📁',
+      connections: [],
+      source: { type: 'file' as const, path: dir },
+    };
+  });
+}
+
+/** Load repo-aware content: issues, PRs, README, and directory structure. */
+export async function loadRepoContent(source: SourceConfig): Promise<KBNode[]> {
+  const [issues, prs, tree, readme] = await Promise.all([
+    fetchIssues(source).catch(() => [] as GHIssue[]),
+    fetchPullRequests(source).catch(() => [] as GHIssue[]),
+    fetchTree(source).catch(() => [] as GHTreeItem[]),
+    fetchFile(source, 'README.md').catch(() => null),
+  ]);
+
+  const nodes: KBNode[] = [];
+
+  if (readme) {
+    nodes.push(readmeToNode(readme));
+  }
+
+  nodes.push(...issues.map(issueToNode));
+  nodes.push(...prs.map(prToNode));
+  nodes.push(...treeToNodes(tree));
+
+  return nodes;
+}
+
+// ── Cluster extraction ─────────────────────────────────────
+
+/** Extract cluster definitions from nodes + config. */
+export function extractClusters(
+  nodes: KBNode[],
+  config: KBConfig
+): Cluster[] {
+  const configClusters = new Map(
+    Object.entries(config.clusters).map(([id, c]) => [id, { id, ...c }])
+  );
+
+  // Auto-generate cluster colors for clusters not in config
+  const palette = [
+    '#E8A838', '#4A9CC8', '#8CB050', '#C07840',
+    '#D4A050', '#5A98A8', '#9A8A78', '#C04040',
+    '#A86FDF', '#39FF14', '#FF6B6B', '#4ECDC4',
+  ];
+  let colorIdx = 0;
+
+  const seenIds = new Set<string>();
+  for (const node of nodes) {
+    if (!seenIds.has(node.cluster)) {
+      seenIds.add(node.cluster);
+      if (!configClusters.has(node.cluster)) {
+        configClusters.set(node.cluster, {
+          id: node.cluster,
+          name: node.cluster.charAt(0).toUpperCase() + node.cluster.slice(1),
+          color: palette[colorIdx % palette.length],
+        });
+        colorIdx++;
+      }
+    }
+  }
+
+  return [...configClusters.values()];
+}
+
+// ── Config loading ─────────────────────────────────────────
+
+/** Try to load config.yaml from the repo. Falls back to DEFAULT_CONFIG. */
+export async function loadConfig(source: SourceConfig): Promise<KBConfig> {
+  try {
+    const raw = await fetchFile(source, source.path
+      ? `${source.path}/config.yaml`
+      : 'content/config.yaml'
+    );
+    const yaml = await import('yaml');
+    const parsed = yaml.parse(raw) as Partial<KBConfig>;
+    return { ...DEFAULT_CONFIG, ...parsed, source };
+  } catch {
+    return { ...DEFAULT_CONFIG, source };
+  }
+}

--- a/src/hooks/useKnowledgeBase.ts
+++ b/src/hooks/useKnowledgeBase.ts
@@ -1,0 +1,59 @@
+import { useState, useEffect } from 'react';
+import type { KBGraph, KBConfig, SourceConfig } from '../types';
+import { DEFAULT_CONFIG } from '../types';
+import {
+  loadConfig,
+  loadRepoContent,
+  loadAuthoredContent,
+  extractClusters,
+  buildGraph,
+} from '../engine';
+
+export type LoadingState =
+  | { status: 'loading' }
+  | { status: 'ready'; graph: KBGraph; config: KBConfig }
+  | { status: 'error'; error: string };
+
+/**
+ * Hook that loads the knowledge base from GitHub at runtime.
+ * Fetches config, content (repo-aware or authored), computes graph.
+ */
+export function useKnowledgeBase(sourceOverride?: SourceConfig): LoadingState {
+  const [state, setState] = useState<LoadingState>({ status: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      setState({ status: 'loading' });
+      try {
+        const source = sourceOverride ?? DEFAULT_CONFIG.source;
+        const config = await loadConfig(source);
+
+        // Load content based on mode
+        const nodes = config.source.path
+          ? await loadAuthoredContent(source, config.source.path)
+          : await loadRepoContent(source);
+
+        const clusters = extractClusters(nodes, config);
+        const graph = buildGraph(nodes, clusters);
+
+        if (!cancelled) {
+          setState({ status: 'ready', graph, config });
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setState({
+            status: 'error',
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    }
+
+    void load();
+    return () => { cancelled = true; };
+  }, [sourceOverride]);
+
+  return state;
+}

--- a/src/styles/visuals.css
+++ b/src/styles/visuals.css
@@ -1,0 +1,115 @@
+/* Visual identity system styles */
+
+/* ── Hero (full-bleed) ──────────────────────────────── */
+.kb-hero {
+  position: relative;
+  width: 100%;
+  height: 60vh;
+  min-height: 300px;
+  max-height: 680px;
+  overflow: hidden;
+}
+
+.kb-hero-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  animation: heroReveal 1s ease-out forwards;
+  will-change: transform, opacity;
+}
+
+.kb-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(13, 13, 13, 0.1) 0%,
+    rgba(13, 13, 13, 0.3) 50%,
+    rgba(13, 13, 13, 0.95) 85%,
+    var(--bg) 100%
+  );
+}
+
+@keyframes heroReveal {
+  from { opacity: 0; transform: scale(1.05); }
+  to   { opacity: 1; transform: scale(1); }
+}
+
+/* ── HUD blurred background ─────────────────────────── */
+.kb-hud-bg {
+  position: absolute;
+  inset: 0;
+  background-size: cover;
+  background-position: center;
+  opacity: 0.12;
+  filter: blur(24px) saturate(1.3);
+  transition: background-image 0.6s;
+  pointer-events: none;
+}
+
+/* ── Image thumbnails ───────────────────────────────── */
+.kb-visual {
+  object-fit: cover;
+  border-radius: 8px;
+  flex-shrink: 0;
+}
+
+.kb-visual--circular {
+  border-radius: 50%;
+}
+
+.kb-visual--card {
+  border: 1px solid var(--border);
+}
+
+.kb-visual--header {
+  border: 2px solid var(--border);
+}
+
+.kb-visual--hud-thumb {
+  border: 1px solid rgba(212, 168, 67, 0.1);
+}
+
+.kb-visual--edge-preview {
+  border: 2px solid var(--border);
+  border-radius: 50%;
+}
+
+.kb-visual--connection {
+  border: 1px solid var(--border);
+}
+
+/* ── Emoji ──────────────────────────────────────────── */
+.kb-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.kb-emoji--card { font-size: 28px; }
+.kb-emoji--header { font-size: 48px; }
+.kb-emoji--hud-thumb { font-size: 20px; }
+.kb-emoji--edge-preview { font-size: 20px; }
+.kb-emoji--connection { font-size: 18px; }
+
+/* ── Letter fallback ────────────────────────────────── */
+.kb-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  color: var(--fg-muted);
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.kb-letter--card { width: 48px; height: 48px; font-size: 20px; }
+.kb-letter--header { width: 80px; height: 80px; font-size: 32px; }
+.kb-letter--hud-thumb { width: 44px; height: 44px; font-size: 18px; border-radius: 6px; }
+.kb-letter--edge-preview { width: 40px; height: 40px; font-size: 16px; border-radius: 50%; }
+.kb-letter--connection { width: 36px; height: 36px; font-size: 14px; border-radius: 6px; }


### PR DESCRIPTION
Implements the foundational runtime modules for kbexplorer.

## Modules

| Module | Path | Purpose |
|--------|------|---------|
| GitHub client | src/api/github.ts | Fetch files, trees, issues, PRs with caching + rate limits |
| Content parser | src/engine/parser.ts | Authored (frontmatter+markdown) + repo-aware (issues/PRs/README) |
| Graph engine | src/engine/graph.ts | Builds edges, computes related nodes (max 8, by degree) |
| Visual system | src/components/NodeVisual.tsx | 7 surfaces × 4 modes (sprites/heroes/emoji/none) |
| KB hook | src/hooks/useKnowledgeBase.ts | Ties API + parser + graph into one loading hook |
| Styles | src/styles/visuals.css | Hero overlay, blur bg, circular crops, animations |

## Default experience

App loads in repo-aware mode, fetches content from anokye-labs/kbexplorer via GitHub API, and renders a node list.

Closes #3
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/4" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
