### PR TITLE
feat: constellation graph view with vis-network

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
+import GraphView from './views/GraphView';
 import './styles/visuals.css';
 
 function LoadingScreen() {
@@ -84,10 +85,7 @@ function Explorer() {
         </div>
       } />
       <Route path="/graph" element={
-        <div style={{ padding: '2rem' }}>
-          <h1 style={{ fontFamily: 'var(--font-heading)' }}>Constellation</h1>
-          <p style={{ color: 'var(--fg-muted)' }}>Graph view — coming next</p>
-        </div>
+        <GraphView graph={graph} config={config} />
       } />
       <Route path="/node/:id" element={
         <div style={{ padding: '2rem' }}>

--- a/src/styles/graph.css
+++ b/src/styles/graph.css
@@ -1,0 +1,100 @@
+/* ── Graph View ─────────────────────────────────────── */
+
+.graph-container {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  background: var(--bg);
+  z-index: 1;
+}
+
+.graph-canvas {
+  width: 100%;
+  height: 100%;
+}
+
+/* ── Back Button ────────────────────────────────────── */
+
+.graph-back {
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  z-index: 10;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  background: rgba(13, 13, 13, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  color: var(--fg);
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  text-decoration: none;
+  backdrop-filter: blur(12px);
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.graph-back:hover {
+  background: rgba(30, 28, 24, 0.9);
+  border-color: rgba(255, 255, 255, 0.14);
+  text-decoration: none;
+}
+
+/* ── Cluster Legend ──────────────────────────────────── */
+
+.graph-legend {
+  position: absolute;
+  bottom: 20px;
+  left: 20px;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 18px;
+  background: rgba(13, 13, 13, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  backdrop-filter: blur(12px);
+  min-width: 140px;
+}
+
+.graph-legend-title {
+  font-family: var(--font-body);
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-muted);
+  margin-bottom: 2px;
+}
+
+.graph-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  color: var(--fg);
+  transition: background 0.15s;
+  user-select: none;
+}
+
+.graph-legend-item:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.graph-legend-item--active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.graph-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}

--- a/src/views/GraphView.tsx
+++ b/src/views/GraphView.tsx
@@ -1,0 +1,168 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Network } from 'vis-network/standalone';
+import { DataSet } from 'vis-data';
+import type { KBGraph, KBConfig } from '../types';
+import { getVisNodeConfig } from '../components/NodeVisual';
+import { getNodeDegrees } from '../engine/graph';
+import '../styles/graph.css';
+
+interface GraphViewProps {
+  graph: KBGraph;
+  config: KBConfig;
+}
+
+export default function GraphView({ graph, config }: GraphViewProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const networkRef = useRef<Network | null>(null);
+  // Keep a ref to the nodes DataSet so we can update it from the cluster filter
+  const nodesRef = useRef<DataSet<Record<string, unknown>> | null>(null);
+  const [activeCluster, setActiveCluster] = useState<string | null>(null);
+
+  const clusterColorMap = new Map(
+    graph.clusters.map(c => [c.id, c.color]),
+  );
+
+  const degrees = getNodeDegrees(graph);
+
+  const handleClusterClick = useCallback(
+    (clusterId: string) => {
+      const next = activeCluster === clusterId ? null : clusterId;
+      setActiveCluster(next);
+
+      const ds = nodesRef.current;
+      if (!ds) return;
+
+      if (!next) {
+        const updates = graph.nodes.map(n => {
+          const deg = degrees.get(n.id) ?? 0;
+          const size = Math.min(20 + deg * 5, 50);
+          const color = clusterColorMap.get(n.cluster) ?? '#9A8A78';
+          return {
+            id: n.id,
+            opacity: 1,
+            ...getVisNodeConfig(n, config.visuals.mode, config.source, color, size),
+            label: n.title,
+            font: { color: '#C8B8A8', face: 'General Sans', size: 12 },
+          };
+        });
+        ds.update(updates);
+        return;
+      }
+
+      const updates = graph.nodes.map(n => {
+        const inCluster = n.cluster === next;
+        const deg = degrees.get(n.id) ?? 0;
+        const size = Math.min(20 + deg * 5, 50);
+        const color = clusterColorMap.get(n.cluster) ?? '#9A8A78';
+        return {
+          id: n.id,
+          opacity: inCluster ? 1 : 0.15,
+          ...getVisNodeConfig(n, config.visuals.mode, config.source, color, size),
+          label: n.title,
+          font: {
+            color: inCluster ? '#C8B8A8' : 'rgba(200,184,168,0.15)',
+            face: 'General Sans',
+            size: 12,
+          },
+        };
+      });
+      ds.update(updates);
+    },
+    [activeCluster, graph, config, degrees, clusterColorMap],
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const nodeData = graph.nodes.map(n => {
+      const deg = degrees.get(n.id) ?? 0;
+      const size = Math.min(20 + deg * 5, 50);
+      const color = clusterColorMap.get(n.cluster) ?? '#9A8A78';
+      const visConfig = getVisNodeConfig(n, config.visuals.mode, config.source, color, size);
+
+      return {
+        id: n.id,
+        label: n.title,
+        title: `${n.title}\n${deg} connection${deg === 1 ? '' : 's'}`,
+        font: { color: '#C8B8A8', face: 'General Sans', size: 12 },
+        ...visConfig,
+      };
+    });
+
+    const edgeData = graph.edges.map((e, i) => ({
+      id: `e${i}`,
+      from: e.from,
+      to: e.to,
+      title: e.description,
+      color: { color: '#2A2620', hover: '#4A4438', highlight: '#4A4438' },
+      width: 1.5,
+      dashes: [4, 6],
+    }));
+
+    const nodes = new DataSet(nodeData);
+    const edges = new DataSet(edgeData);
+    nodesRef.current = nodes;
+
+    const network = new Network(containerRef.current, { nodes, edges }, {
+      physics: {
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -80,
+          centralGravity: 0.01,
+          springLength: 120,
+          springConstant: 0.08,
+          damping: 0.4,
+        },
+        stabilization: { iterations: 150 },
+      },
+      interaction: {
+        hover: true,
+        tooltipDelay: 200,
+        navigationButtons: false,
+        keyboard: false,
+      },
+      edges: {
+        smooth: { enabled: true, type: 'continuous', roundness: 0.5 },
+      },
+    });
+
+    network.on('click', (params: { nodes: string[] }) => {
+      if (params.nodes.length > 0) {
+        window.location.hash = `/node/${encodeURIComponent(params.nodes[0])}`;
+      }
+    });
+
+    networkRef.current = network;
+
+    return () => {
+      network.destroy();
+      networkRef.current = null;
+      nodesRef.current = null;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph, config]);
+
+  return (
+    <div className="graph-container">
+      <a className="graph-back" href="#/">
+        ← Overview
+      </a>
+
+      <div ref={containerRef} className="graph-canvas" />
+
+      <div className="graph-legend">
+        <div className="graph-legend-title">Clusters</div>
+        {graph.clusters.map(c => (
+          <div
+            key={c.id}
+            className={`graph-legend-item${activeCluster === c.id ? ' graph-legend-item--active' : ''}`}
+            onClick={() => handleClusterClick(c.id)}
+          >
+            <span className="graph-legend-dot" style={{ background: c.color }} />
+            {c.name}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Full-viewport interactive graph visualization at \#/graph\ using vis-network.

### Changes
- **GraphView component** (\src/views/GraphView.tsx\): vis-network constellation with forceAtlas2Based physics, node sizing by degree, cluster-colored nodes via \getVisNodeConfig\
- **Cluster legend**: bottom-left overlay with click-to-filter (dims non-matching nodes)
- **Navigation**: node click → \#/node/{id}\, back button → \#/\
- **Tooltips**: node hover shows title + connection count, edge hover shows description
- **Styling** (\src/styles/graph.css\): dark theme, fixed full-viewport canvas, glassmorphic overlays
- **App.tsx**: wired GraphView into the \/graph\ route

Closes #5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/6" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
