### PR TITLE
feat: reading view with prose, connections, and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { HashRouter, Routes, Route, useParams } from 'react-router-dom';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
+import { ReadingView } from './views/ReadingView';
 import './styles/visuals.css';
+import './styles/reading.css';
 
 function LoadingScreen() {
   return (
@@ -36,6 +38,11 @@ function ErrorScreen({ message }: { message: string }) {
       </p>
     </div>
   );
+}
+
+function ReadingRoute({ graph, config }: { graph: import('./types').KBGraph; config: import('./types').KBConfig }) {
+  const { id } = useParams<{ id: string }>();
+  return <ReadingView graph={graph} config={config} nodeId={id ?? ''} />;
 }
 
 function Explorer() {
@@ -89,11 +96,7 @@ function Explorer() {
           <p style={{ color: 'var(--fg-muted)' }}>Graph view — coming next</p>
         </div>
       } />
-      <Route path="/node/:id" element={
-        <div style={{ padding: '2rem' }}>
-          <p style={{ color: 'var(--fg-muted)' }}>Reading view — coming next</p>
-        </div>
-      } />
+      <Route path="/node/:id" element={<ReadingRoute graph={graph} config={config} />} />
     </Routes>
   );
 }

--- a/src/styles/reading.css
+++ b/src/styles/reading.css
@@ -1,0 +1,419 @@
+/* ── Reading View ─────────────────────────────────────── */
+
+.kb-reading {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ── Back link ───────────────────────────────────────── */
+.kb-reading-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 1rem 1.5rem;
+  font-size: 0.875rem;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+
+.kb-reading-back:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+/* ── Header ──────────────────────────────────────────── */
+.kb-reading-header {
+  padding: 0 1.5rem 2rem;
+  max-width: 1120px;
+  width: 100%;
+  margin: 0 auto;
+}
+
+.kb-reading-header--hero {
+  position: relative;
+  margin-top: -8rem;
+  z-index: 1;
+  padding-top: 0;
+}
+
+.kb-reading-header__visual {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.kb-reading-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  margin-bottom: 0.5rem;
+}
+
+.kb-reading-cluster__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.kb-reading-title {
+  font-family: var(--font-heading);
+  font-size: 2.5rem;
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+
+/* ── Content layout ──────────────────────────────────── */
+.kb-reading-body {
+  display: flex;
+  flex-direction: column;
+  max-width: 1120px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 1.5rem 3rem;
+  gap: 3rem;
+}
+
+/* ── Prose ────────────────────────────────────────────── */
+.kb-prose {
+  max-width: 780px;
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--fg);
+}
+
+.kb-prose h1 {
+  font-family: var(--font-heading);
+  font-size: 2rem;
+  font-weight: 400;
+  margin: 2.5rem 0 1rem;
+  line-height: 1.2;
+}
+
+.kb-prose h2 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 400;
+  margin: 2rem 0 0.75rem;
+  line-height: 1.25;
+}
+
+.kb-prose h3 {
+  font-family: var(--font-heading);
+  font-size: 1.2rem;
+  font-weight: 400;
+  margin: 1.75rem 0 0.5rem;
+  line-height: 1.3;
+}
+
+.kb-prose h4 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 1.5rem 0 0.5rem;
+  line-height: 1.4;
+}
+
+.kb-prose p {
+  margin: 0 0 1.25rem;
+}
+
+.kb-prose ul,
+.kb-prose ol {
+  margin: 0 0 1.25rem;
+  padding-left: 1.5em;
+}
+
+.kb-prose li {
+  margin-bottom: 0.35rem;
+}
+
+.kb-prose li > ul,
+.kb-prose li > ol {
+  margin-top: 0.35rem;
+  margin-bottom: 0;
+}
+
+.kb-prose blockquote {
+  margin: 1.5rem 0;
+  padding: 0.75rem 1.25rem;
+  border-left: 3px solid var(--accent);
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0 6px 6px 0;
+  color: var(--fg-muted);
+}
+
+.kb-prose blockquote p:last-child {
+  margin-bottom: 0;
+}
+
+.kb-prose code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  padding: 0.15em 0.4em;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  border: 1px solid var(--border);
+}
+
+.kb-prose pre {
+  margin: 1.5rem 0;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+
+.kb-prose pre code {
+  padding: 0;
+  background: none;
+  border: none;
+  font-size: 0.85rem;
+}
+
+.kb-prose a {
+  color: var(--accent);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.kb-prose a:hover {
+  color: var(--fg);
+}
+
+.kb-prose hr {
+  margin: 2rem 0;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+
+.kb-prose table {
+  width: 100%;
+  margin: 1.5rem 0;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.kb-prose th,
+.kb-prose td {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  text-align: left;
+}
+
+.kb-prose th {
+  background: rgba(255, 255, 255, 0.04);
+  font-weight: 600;
+}
+
+.kb-prose img {
+  max-width: 100%;
+  border-radius: 8px;
+  margin: 1rem 0;
+}
+
+/* ── Connections ──────────────────────────────────────── */
+.kb-connections {
+  flex-shrink: 0;
+}
+
+.kb-connections__title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+  color: var(--fg);
+}
+
+.kb-connections__count {
+  color: var(--fg-muted);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  margin-left: 0.5rem;
+}
+
+.kb-connections__list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.kb-connection-card {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  text-decoration: none;
+  color: var(--fg);
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.kb-connection-card:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.14);
+  text-decoration: none;
+}
+
+.kb-connection-card__info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.kb-connection-card__title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kb-connection-card__desc {
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.kb-connection-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  padding: 2px 8px;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 9999px;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.kb-connection-pill__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+/* ── Prev / Next navigation ──────────────────────────── */
+.kb-nav-footer {
+  margin-top: auto;
+  border-top: 1px solid var(--border);
+  display: flex;
+}
+
+.kb-nav-footer__link {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 1.25rem 1.5rem;
+  text-decoration: none;
+  color: var(--fg);
+  transition: background 0.15s;
+}
+
+.kb-nav-footer__link:hover {
+  background: rgba(255, 255, 255, 0.03);
+  text-decoration: none;
+}
+
+.kb-nav-footer__link--next {
+  text-align: right;
+  align-items: flex-end;
+  border-left: 1px solid var(--border);
+}
+
+.kb-nav-footer__link--disabled {
+  pointer-events: none;
+  opacity: 0.3;
+}
+
+.kb-nav-footer__label {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.kb-nav-footer__title {
+  font-family: var(--font-heading);
+  font-size: 1.05rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.kb-nav-footer__cluster {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+/* ── Not found ───────────────────────────────────────── */
+.kb-reading-notfound {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  gap: 1rem;
+  text-align: center;
+  padding: 2rem;
+}
+
+.kb-reading-notfound h1 {
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+}
+
+/* ── Responsive ──────────────────────────────────────── */
+@media (min-width: 1024px) {
+  .kb-reading-body {
+    flex-direction: row;
+  }
+
+  .kb-prose {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .kb-connections {
+    width: 280px;
+    position: sticky;
+    top: 2rem;
+    align-self: flex-start;
+  }
+}
+
+@media (max-width: 767px) {
+  .kb-reading-back {
+    padding: 0.75rem 1rem;
+  }
+
+  .kb-reading-header {
+    padding: 0 1rem 1.5rem;
+  }
+
+  .kb-reading-title {
+    font-size: 1.75rem;
+  }
+
+  .kb-reading-body {
+    padding: 0 1rem 2rem;
+  }
+
+  .kb-nav-footer__link {
+    padding: 1rem;
+  }
+}

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -1,0 +1,171 @@
+import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
+import { NodeVisual } from '../components/NodeVisual';
+
+interface ReadingViewProps {
+  graph: KBGraph;
+  config: KBConfig;
+  nodeId: string;
+}
+
+function findCluster(config: KBConfig, clusters: Cluster[], clusterId: string) {
+  const meta = config.clusters[clusterId];
+  const cluster = clusters.find(c => c.id === clusterId);
+  return {
+    name: meta?.name ?? cluster?.name ?? clusterId,
+    color: meta?.color ?? cluster?.color ?? '#888',
+  };
+}
+
+function getClusterNodes(nodes: KBNode[], clusterId: string): KBNode[] {
+  return nodes
+    .filter(n => n.cluster === clusterId)
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
+  const node = graph.nodes.find(n => n.id === nodeId);
+
+  if (!node) {
+    return (
+      <div className="kb-reading-notfound">
+        <span style={{ fontSize: 48 }}>🔍</span>
+        <h1>Node not found</h1>
+        <p style={{ color: 'var(--fg-muted)' }}>
+          No node with id "{nodeId}" exists in this knowledge base.
+        </p>
+        <a href="#/" className="kb-reading-back">← Back to overview</a>
+      </div>
+    );
+  }
+
+  const mode = config.visuals.mode;
+  const source = config.source;
+  const cluster = findCluster(config, graph.clusters, node.cluster);
+
+  // Connected nodes
+  const relatedIds = graph.related[nodeId] ?? [];
+  const connectionMap = new Map(
+    node.connections.map(c => [c.to, c.description])
+  );
+  const connectedNodes = relatedIds
+    .map(id => graph.nodes.find(n => n.id === id))
+    .filter((n): n is KBNode => n != null);
+
+  // Prev/next within cluster
+  const clusterNodes = getClusterNodes(graph.nodes, node.cluster);
+  const idx = clusterNodes.findIndex(n => n.id === nodeId);
+  const prev = idx > 0 ? clusterNodes[idx - 1] : null;
+  const next = idx < clusterNodes.length - 1 ? clusterNodes[idx + 1] : null;
+
+  const showHero = mode === 'heroes' && !!node.image;
+
+  return (
+    <div className="kb-reading">
+      {/* Hero image */}
+      {showHero && (
+        <NodeVisual node={node} mode={mode} surface="hero" source={source} />
+      )}
+
+      {/* Back link */}
+      <a href="#/" className="kb-reading-back">← Back to overview</a>
+
+      {/* Header */}
+      <header className={`kb-reading-header ${showHero ? 'kb-reading-header--hero' : ''}`}>
+        <div className="kb-reading-header__visual">
+          {!showHero && (mode === 'sprites' && node.sprite) && (
+            <NodeVisual node={node} mode={mode} surface="header" source={source} />
+          )}
+          {!showHero && mode === 'emoji' && node.emoji && (
+            <NodeVisual node={node} mode="emoji" surface="header" source={source} />
+          )}
+        </div>
+        <div className="kb-reading-cluster">
+          <span
+            className="kb-reading-cluster__dot"
+            style={{ background: cluster.color }}
+          />
+          {cluster.name}
+        </div>
+        <h1 className="kb-reading-title">{node.title}</h1>
+      </header>
+
+      {/* Body: prose + connections */}
+      <div className="kb-reading-body">
+        <div
+          className="kb-prose"
+          dangerouslySetInnerHTML={{ __html: node.content }}
+        />
+
+        {connectedNodes.length > 0 && (
+          <aside className="kb-connections">
+            <h2 className="kb-connections__title">
+              Connected
+              <span className="kb-connections__count">{connectedNodes.length}</span>
+            </h2>
+            <div className="kb-connections__list">
+              {connectedNodes.map(cn => {
+                const cnCluster = findCluster(config, graph.clusters, cn.cluster);
+                const desc = connectionMap.get(cn.id) ?? '';
+                return (
+                  <a
+                    key={cn.id}
+                    href={`#/node/${encodeURIComponent(cn.id)}`}
+                    className="kb-connection-card"
+                  >
+                    <NodeVisual
+                      node={cn}
+                      mode={mode}
+                      surface="connection"
+                      source={source}
+                    />
+                    <div className="kb-connection-card__info">
+                      <span className="kb-connection-card__title">{cn.title}</span>
+                      {desc && (
+                        <span className="kb-connection-card__desc">{desc}</span>
+                      )}
+                    </div>
+                    <span className="kb-connection-pill">
+                      <span
+                        className="kb-connection-pill__dot"
+                        style={{ background: cnCluster.color }}
+                      />
+                      {cnCluster.name}
+                    </span>
+                  </a>
+                );
+              })}
+            </div>
+          </aside>
+        )}
+      </div>
+
+      {/* Prev / Next */}
+      <nav className="kb-nav-footer">
+        <a
+          href={prev ? `#/node/${encodeURIComponent(prev.id)}` : undefined}
+          className={`kb-nav-footer__link ${!prev ? 'kb-nav-footer__link--disabled' : ''}`}
+          aria-disabled={!prev}
+        >
+          <span className="kb-nav-footer__label">← Previous</span>
+          <span className="kb-nav-footer__title">
+            {prev?.emoji && <span>{prev.emoji}</span>}
+            {prev?.title ?? '—'}
+          </span>
+          <span className="kb-nav-footer__cluster">{cluster.name}</span>
+        </a>
+        <a
+          href={next ? `#/node/${encodeURIComponent(next.id)}` : undefined}
+          className={`kb-nav-footer__link kb-nav-footer__link--next ${!next ? 'kb-nav-footer__link--disabled' : ''}`}
+          aria-disabled={!next}
+        >
+          <span className="kb-nav-footer__label">Next →</span>
+          <span className="kb-nav-footer__title">
+            {next?.emoji && <span>{next.emoji}</span>}
+            {next?.title ?? '—'}
+          </span>
+          <span className="kb-nav-footer__cluster">{cluster.name}</span>
+        </a>
+      </nav>
+    </div>
+  );
+}


### PR DESCRIPTION
## Reading View

Implements the detail panel shown when navigating to \#/node/{id}\.

### What's included

- **ReadingView component** (\src/views/ReadingView.tsx\)
  - Hero/sprite/emoji header based on visual mode
  - Markdown prose rendered via \.kb-prose\ styles
  - Connected nodes sidebar (desktop) / section (mobile)
  - Prev/next navigation within same cluster
  - Not-found state with back link

- **Reading styles** (\src/styles/reading.css\)
  - Full prose typography (headings, code, blockquotes, tables, lists, links, hr)
  - Connection cards with cluster pills
  - Responsive layout: sidebar at 1024px+, stacked below 768px
  - Prev/next footer navigation

- **App.tsx** — Wired \/node/:id\ route to ReadingView via ReadingRoute wrapper
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
