### PR TITLE
feat: theme system, keyboard navigation, and HUD

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
+import { useState, useEffect } from 'react';
 import { HashRouter, Routes, Route } from 'react-router-dom';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
+import { useTheme } from './hooks/useTheme';
+import { useKeyboardNav } from './hooks/useKeyboardNav';
+import { HUD } from './components/HUD';
 import './styles/visuals.css';
 
 function LoadingScreen() {
@@ -38,8 +42,47 @@ function ErrorScreen({ message }: { message: string }) {
   );
 }
 
+function useCurrentNodeId(): string | null {
+  const [nodeId, setNodeId] = useState<string | null>(null);
+
+  useEffect(() => {
+    function update() {
+      const match = window.location.hash.match(/#\/node\/(.+)/);
+      setNodeId(match ? decodeURIComponent(match[1]) : null);
+    }
+    update();
+    window.addEventListener('hashchange', update);
+    return () => window.removeEventListener('hashchange', update);
+  }, []);
+
+  return nodeId;
+}
+
+function useIsGraphRoute(): boolean {
+  const [isGraph, setIsGraph] = useState(false);
+
+  useEffect(() => {
+    function update() {
+      setIsGraph(window.location.hash === '#/graph');
+    }
+    update();
+    window.addEventListener('hashchange', update);
+    return () => window.removeEventListener('hashchange', update);
+  }, []);
+
+  return isGraph;
+}
+
 function Explorer() {
   const state = useKnowledgeBase();
+  const [theme, setTheme] = useTheme();
+  const currentNodeId = useCurrentNodeId();
+  const isGraph = useIsGraphRoute();
+
+  useKeyboardNav(
+    state.status === 'ready' ? state.graph : null,
+    setTheme,
+  );
 
   if (state.status === 'loading') return <LoadingScreen />;
   if (state.status === 'error') return <ErrorScreen message={state.error} />;
@@ -47,54 +90,67 @@ function Explorer() {
   const { graph, config } = state;
 
   return (
-    <Routes>
-      <Route path="/" element={
-        <div style={{ padding: '2rem' }}>
-          <h1 style={{ fontFamily: 'var(--font-heading)', marginBottom: '0.5rem' }}>
-            {config.title}
-          </h1>
-          {config.subtitle && (
-            <p style={{ color: 'var(--fg-muted)', marginBottom: '2rem' }}>
-              {config.subtitle}
-            </p>
-          )}
-          <p style={{ color: 'var(--fg-muted)' }}>
-            {graph.nodes.length} nodes · {graph.edges.length} edges · {graph.clusters.length} clusters
-          </p>
-          <div style={{ marginTop: '2rem', display: 'flex', flexDirection: 'column', gap: '8px' }}>
-            {graph.nodes.slice(0, 20).map(node => (
-              <a
-                key={node.id}
-                href={`#/node/${encodeURIComponent(node.id)}`}
-                style={{
-                  display: 'flex', alignItems: 'center', gap: '12px',
-                  padding: '12px 16px',
-                  background: 'rgba(255,255,255,0.03)',
-                  borderRadius: '8px', border: '1px solid var(--border)',
-                }}
-              >
-                <span style={{ fontSize: 20 }}>{node.emoji ?? '📌'}</span>
-                <span>{node.title}</span>
-                <span style={{ color: 'var(--fg-muted)', fontSize: '0.85rem', marginLeft: 'auto' }}>
-                  {node.cluster}
-                </span>
-              </a>
-            ))}
-          </div>
-        </div>
-      } />
-      <Route path="/graph" element={
-        <div style={{ padding: '2rem' }}>
-          <h1 style={{ fontFamily: 'var(--font-heading)' }}>Constellation</h1>
-          <p style={{ color: 'var(--fg-muted)' }}>Graph view — coming next</p>
-        </div>
-      } />
-      <Route path="/node/:id" element={
-        <div style={{ padding: '2rem' }}>
-          <p style={{ color: 'var(--fg-muted)' }}>Reading view — coming next</p>
-        </div>
-      } />
-    </Routes>
+    <>
+      <div style={{ paddingBottom: isGraph ? 0 : 180 }}>
+        <Routes>
+          <Route path="/" element={
+            <div style={{ padding: '2rem' }}>
+              <h1 style={{ fontFamily: 'var(--font-heading)', marginBottom: '0.5rem' }}>
+                {config.title}
+              </h1>
+              {config.subtitle && (
+                <p style={{ color: 'var(--fg-muted)', marginBottom: '2rem' }}>
+                  {config.subtitle}
+                </p>
+              )}
+              <p style={{ color: 'var(--fg-muted)' }}>
+                {graph.nodes.length} nodes · {graph.edges.length} edges · {graph.clusters.length} clusters
+              </p>
+              <div style={{ marginTop: '2rem', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                {graph.nodes.slice(0, 20).map(node => (
+                  <a
+                    key={node.id}
+                    href={`#/node/${encodeURIComponent(node.id)}`}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: '12px',
+                      padding: '12px 16px',
+                      background: 'rgba(255,255,255,0.03)',
+                      borderRadius: '8px', border: '1px solid var(--border)',
+                    }}
+                  >
+                    <span style={{ fontSize: 20 }}>{node.emoji ?? '📌'}</span>
+                    <span>{node.title}</span>
+                    <span style={{ color: 'var(--fg-muted)', fontSize: '0.85rem', marginLeft: 'auto' }}>
+                      {node.cluster}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          } />
+          <Route path="/graph" element={
+            <div style={{ padding: '2rem' }}>
+              <h1 style={{ fontFamily: 'var(--font-heading)' }}>Constellation</h1>
+              <p style={{ color: 'var(--fg-muted)' }}>Graph view — coming next</p>
+            </div>
+          } />
+          <Route path="/node/:id" element={
+            <div style={{ padding: '2rem' }}>
+              <p style={{ color: 'var(--fg-muted)' }}>Reading view — coming next</p>
+            </div>
+          } />
+        </Routes>
+      </div>
+      {!isGraph && (
+        <HUD
+          graph={graph}
+          config={config}
+          currentNodeId={currentNodeId}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
+import { NodeVisual } from './NodeVisual';
+import '../styles/hud.css';
+
+interface HUDProps {
+  graph: KBGraph;
+  config: KBConfig;
+  currentNodeId: string | null;
+  theme: Theme;
+  onThemeChange: (theme: Theme) => void;
+}
+
+const FONT_SIZES = [0.92, 1.0, 1.08, 1.18, 1.3];
+const COL_WIDTHS = [580, 680, 780, 960, 1200];
+
+function readPersisted(key: string, fallback: number): number {
+  try {
+    const v = localStorage.getItem(key);
+    if (v !== null) {
+      const n = Number(v);
+      if (!Number.isNaN(n)) return n;
+    }
+  } catch { /* ignore */ }
+  return fallback;
+}
+
+export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [fontSize, setFontSize] = useState(() => readPersisted('kbe-font-size', 1));
+  const [colWidth, setColWidth] = useState(() => readPersisted('kbe-col-width', 1));
+
+  const currentNode = currentNodeId
+    ? graph.nodes.find(n => n.id === currentNodeId) ?? null
+    : null;
+
+  const currentIdx = currentNode
+    ? graph.nodes.findIndex(n => n.id === currentNodeId)
+    : -1;
+
+  const relatedIds = currentNodeId ? (graph.related[currentNodeId] ?? []) : [];
+  const relatedNodes = relatedIds
+    .map(id => graph.nodes.find(n => n.id === id))
+    .filter((n): n is KBNode => n != null);
+
+  // Apply CSS variables
+  useEffect(() => {
+    document.documentElement.style.setProperty('--prose-font-size', `${FONT_SIZES[fontSize]}rem`);
+    localStorage.setItem('kbe-font-size', String(fontSize));
+  }, [fontSize]);
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--prose-max-width', `${COL_WIDTHS[colWidth]}px`);
+    localStorage.setItem('kbe-col-width', String(colWidth));
+  }, [colWidth]);
+
+  // Draw minimap
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = 200 * dpr;
+    canvas.height = 140 * dpr;
+    ctx.scale(dpr, dpr);
+    ctx.clearRect(0, 0, 200, 140);
+
+    const nodes = graph.nodes;
+    if (nodes.length === 0) return;
+
+    // Deterministic layout: hash-based positioning
+    const positions = nodes.map((n, i) => {
+      const angle = (i / nodes.length) * Math.PI * 2;
+      const radius = 45 + (i % 3) * 12;
+      return {
+        x: 100 + Math.cos(angle) * radius,
+        y: 70 + Math.sin(angle) * radius,
+        node: n,
+      };
+    });
+
+    const posMap = new Map(positions.map(p => [p.node.id, p]));
+
+    // Draw edges
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+    ctx.lineWidth = 0.5;
+    for (const edge of graph.edges) {
+      const from = posMap.get(edge.from);
+      const to = posMap.get(edge.to);
+      if (from && to) {
+        ctx.beginPath();
+        ctx.moveTo(from.x, from.y);
+        ctx.lineTo(to.x, to.y);
+        ctx.stroke();
+      }
+    }
+
+    // Draw nodes
+    const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
+    for (const p of positions) {
+      const color = clusterColorMap.get(p.node.cluster) ?? '#888';
+      const isCurrent = p.node.id === currentNodeId;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, isCurrent ? 4 : 2.5, 0, Math.PI * 2);
+      ctx.fillStyle = isCurrent ? '#E8C350' : color;
+      ctx.fill();
+      if (isCurrent) {
+        ctx.strokeStyle = '#E8C350';
+        ctx.lineWidth = 1;
+        ctx.stroke();
+      }
+    }
+  }, [graph, currentNodeId]);
+
+  const navigateTo = useCallback((hash: string) => {
+    window.location.hash = hash;
+  }, []);
+
+  const goPrev = () => {
+    if (currentIdx < 0) return;
+    const prev = (currentIdx - 1 + graph.nodes.length) % graph.nodes.length;
+    navigateTo(`#/node/${encodeURIComponent(graph.nodes[prev].id)}`);
+  };
+
+  const goNext = () => {
+    if (currentIdx < 0) return;
+    const next = (currentIdx + 1) % graph.nodes.length;
+    navigateTo(`#/node/${encodeURIComponent(graph.nodes[next].id)}`);
+  };
+
+  return (
+    <div className="hud">
+      {/* ── Left: Minimap ─── */}
+      <div className="hud-panel hud-panel--left">
+        <canvas
+          ref={canvasRef}
+          className="hud-minimap"
+          width={200}
+          height={140}
+          onClick={() => navigateTo('#/graph')}
+          title="Open graph view"
+        />
+      </div>
+
+      {/* ── Center: Navigation ─── */}
+      <div className="hud-panel hud-panel--center">
+        <div className="hud-nav-row">
+          <button className="hud-btn" onClick={() => navigateTo('#/graph')}>MAP</button>
+          <button
+            className="hud-btn hud-btn--nav"
+            onClick={goPrev}
+            disabled={!currentNode}
+            title="Previous node (←)"
+          >◀</button>
+          {currentNode ? (
+            <div className="hud-current-node">
+              <span style={{ fontSize: 20 }}>{currentNode.emoji ?? '📌'}</span>
+              <span className="hud-current-title">{currentNode.title}</span>
+              <span className="hud-current-cluster">{currentNode.cluster}</span>
+            </div>
+          ) : (
+            <span className="hud-placeholder">Click any node to begin reading</span>
+          )}
+          <button
+            className="hud-btn hud-btn--nav"
+            onClick={goNext}
+            disabled={!currentNode}
+            title="Next node (→)"
+          >▶</button>
+        </div>
+
+        <div className="hud-nav-row" style={{ alignItems: 'flex-start' }}>
+          <span className="hud-related-label">Related</span>
+          <div className="hud-related-strip">
+            {relatedNodes.length > 0 ? (
+              relatedNodes.map(n => (
+                <a
+                  key={n.id}
+                  className="hud-related-card"
+                  href={`#/node/${encodeURIComponent(n.id)}`}
+                >
+                  <NodeVisual
+                    node={n}
+                    mode={config.visuals.mode}
+                    surface="hud-thumb"
+                    source={config.source}
+                  />
+                  <span className="hud-related-title">{n.title}</span>
+                </a>
+              ))
+            ) : currentNode ? (
+              <span className="hud-placeholder" style={{ fontSize: '0.78rem' }}>No related nodes</span>
+            ) : null}
+          </div>
+        </div>
+      </div>
+
+      {/* ── Right: Reading Tools ─── */}
+      <div className="hud-panel hud-panel--right">
+        {/* Theme switcher */}
+        <div className="hud-tool-row">
+          <span className="hud-tool-label">Theme</span>
+          {(['dark', 'light', 'sepia'] as Theme[]).map(t => (
+            <button
+              key={t}
+              className={`hud-theme-btn hud-theme-btn--${t} ${theme === t ? 'hud-theme-btn--active' : ''}`}
+              onClick={() => onThemeChange(t)}
+              title={t}
+            />
+          ))}
+        </div>
+
+        {/* Font size */}
+        <div className="hud-tool-row">
+          <span className="hud-tool-label">Font</span>
+          <input
+            type="range"
+            className="hud-range"
+            min={0}
+            max={4}
+            step={1}
+            value={fontSize}
+            onChange={e => setFontSize(Number(e.target.value))}
+            title={`Font size: ${FONT_SIZES[fontSize]}rem`}
+          />
+        </div>
+
+        {/* Column width */}
+        <div className="hud-tool-row">
+          <span className="hud-tool-label">Width</span>
+          <input
+            type="range"
+            className="hud-range"
+            min={0}
+            max={4}
+            step={1}
+            value={colWidth}
+            onChange={e => setColWidth(Number(e.target.value))}
+            title={`Column width: ${COL_WIDTHS[colWidth]}px`}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,66 @@
+import { useEffect } from 'react';
+import type { KBGraph, Theme } from '../types';
+import { nextTheme } from './useTheme';
+
+/**
+ * Global keyboard shortcuts.
+ *
+ * t        → cycle theme
+ * /        → overview (#/)
+ * g        → graph (#/graph)
+ * Escape   → back to overview
+ * ←/→      → prev/next node (reading view)
+ */
+export function useKeyboardNav(
+  graph: KBGraph | null,
+  setTheme: (t: Theme) => void,
+): void {
+  useEffect(() => {
+    function handler(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement)?.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+      if ((e.target as HTMLElement)?.isContentEditable) return;
+
+      switch (e.key) {
+        case 't': {
+          const body = document.body;
+          const current: Theme = body.classList.contains('theme-light')
+            ? 'light'
+            : body.classList.contains('theme-sepia')
+              ? 'sepia'
+              : 'dark';
+          setTheme(nextTheme(current));
+          break;
+        }
+        case '/':
+          e.preventDefault();
+          window.location.hash = '#/';
+          break;
+        case 'g':
+          window.location.hash = '#/graph';
+          break;
+        case 'Escape':
+          window.location.hash = '#/';
+          break;
+        case 'ArrowLeft':
+        case 'ArrowRight': {
+          if (!graph) break;
+          const hash = window.location.hash;
+          const match = hash.match(/#\/node\/(.+)/);
+          if (!match) break;
+          const currentId = decodeURIComponent(match[1]);
+          const idx = graph.nodes.findIndex(n => n.id === currentId);
+          if (idx < 0) break;
+          const next = e.key === 'ArrowRight'
+            ? (idx + 1) % graph.nodes.length
+            : (idx - 1 + graph.nodes.length) % graph.nodes.length;
+          window.location.hash = `#/node/${encodeURIComponent(graph.nodes[next].id)}`;
+          break;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [graph, setTheme]);
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Theme } from '../types';
+
+const STORAGE_KEY = 'kbe-theme';
+const THEMES: Theme[] = ['dark', 'light', 'sepia'];
+const CLASS_MAP: Record<Theme, string> = {
+  dark: '',
+  light: 'theme-light',
+  sepia: 'theme-sepia',
+};
+
+function readStored(): Theme {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v && THEMES.includes(v as Theme)) return v as Theme;
+  } catch { /* ignore */ }
+  return 'dark';
+}
+
+function applyBodyClass(theme: Theme) {
+  document.body.classList.remove('theme-light', 'theme-sepia');
+  const cls = CLASS_MAP[theme];
+  if (cls) document.body.classList.add(cls);
+}
+
+export function useTheme(): [Theme, (t: Theme) => void] {
+  const [theme, setThemeState] = useState<Theme>(readStored);
+
+  const setTheme = useCallback((t: Theme) => {
+    setThemeState(t);
+    localStorage.setItem(STORAGE_KEY, t);
+    applyBodyClass(t);
+  }, []);
+
+  // Apply on mount
+  useEffect(() => {
+    applyBodyClass(theme);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return [theme, setTheme];
+}
+
+/** Cycle to the next theme in order. */
+export function nextTheme(current: Theme): Theme {
+  const i = THEMES.indexOf(current);
+  return THEMES[(i + 1) % THEMES.length];
+}

--- a/src/index.css
+++ b/src/index.css
@@ -40,3 +40,23 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+/* ── Light theme ────────────────────────────────────── */
+
+body.theme-light {
+  --bg: #FAFAFA;
+  --fg: #1A1A1A;
+  --fg-muted: #6B6B6B;
+  --accent: #C07820;
+  --border: rgba(0, 0, 0, 0.08);
+}
+
+/* ── Sepia theme ────────────────────────────────────── */
+
+body.theme-sepia {
+  --bg: #F5ECD7;
+  --fg: #2A2520;
+  --fg-muted: #7A7068;
+  --accent: #8B6914;
+  --border: rgba(0, 0, 0, 0.08);
+}

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1,0 +1,305 @@
+/* ── HUD — fixed bottom bar ─────────────────────────── */
+
+.hud {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 170px;
+  background: rgba(13, 13, 13, 0.95);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-top: 1px solid var(--border);
+  display: flex;
+  z-index: 100;
+  font-family: var(--font-body);
+  color: var(--fg);
+}
+
+body.theme-light .hud {
+  background: rgba(240, 240, 240, 0.95);
+}
+
+body.theme-sepia .hud {
+  background: rgba(235, 225, 200, 0.95);
+}
+
+/* ── Panel layout ───────────────────────────────────── */
+
+.hud-panel {
+  display: flex;
+  flex-direction: column;
+  padding: 12px 16px;
+  overflow: hidden;
+}
+
+.hud-panel--left {
+  width: 232px;
+  align-items: center;
+  justify-content: center;
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.hud-panel--center {
+  flex: 1;
+  min-width: 0;
+  gap: 8px;
+}
+
+.hud-panel--right {
+  width: 240px;
+  border-left: 1px solid var(--border);
+  flex-shrink: 0;
+  gap: 10px;
+  justify-content: center;
+}
+
+/* ── Minimap canvas ─────────────────────────────────── */
+
+.hud-minimap {
+  width: 200px;
+  height: 140px;
+  cursor: pointer;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+}
+
+/* ── Center: nav row ────────────────────────────────── */
+
+.hud-nav-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hud-btn {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border);
+  color: var(--fg);
+  border-radius: 6px;
+  padding: 4px 12px;
+  font-size: 0.78rem;
+  font-family: var(--font-mono);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+
+.hud-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+body.theme-light .hud-btn {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+body.theme-light .hud-btn:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+body.theme-sepia .hud-btn {
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.hud-btn--nav {
+  padding: 4px 8px;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.hud-current-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+}
+
+.hud-current-title {
+  font-family: var(--font-heading);
+  font-size: 1rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hud-current-cluster {
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+.hud-placeholder {
+  color: var(--fg-muted);
+  font-size: 0.85rem;
+  text-align: center;
+  padding: 8px 0;
+}
+
+/* ── Center: related strip ──────────────────────────── */
+
+.hud-related-label {
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+}
+
+.hud-related-strip {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex: 1;
+  min-height: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+}
+
+.hud-related-strip::-webkit-scrollbar {
+  height: 4px;
+}
+
+.hud-related-strip::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+.hud-related-card {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px 4px 6px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  flex-shrink: 0;
+  text-decoration: none;
+  color: var(--fg);
+  transition: background 0.15s;
+}
+
+.hud-related-card:hover {
+  background: rgba(255, 255, 255, 0.08);
+  text-decoration: none;
+}
+
+body.theme-light .hud-related-card {
+  background: rgba(0, 0, 0, 0.03);
+}
+
+body.theme-light .hud-related-card:hover {
+  background: rgba(0, 0, 0, 0.06);
+}
+
+.hud-related-title {
+  font-size: 0.78rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 120px;
+}
+
+/* ── Right: reading tools ───────────────────────────── */
+
+.hud-tool-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.hud-tool-label {
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: var(--font-mono);
+  width: 54px;
+  flex-shrink: 0;
+}
+
+/* Theme radio buttons */
+
+.hud-theme-btn {
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  cursor: pointer;
+  padding: 0;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.hud-theme-btn:hover {
+  border-color: var(--accent);
+}
+
+.hud-theme-btn--active {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent);
+}
+
+.hud-theme-btn--dark  { background: #0D0D0D; }
+.hud-theme-btn--light { background: #FAFAFA; }
+.hud-theme-btn--sepia { background: #F5ECD7; }
+
+/* Range sliders */
+
+.hud-range {
+  flex: 1;
+  min-width: 0;
+  height: 4px;
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--border);
+  border-radius: 2px;
+  outline: none;
+  cursor: pointer;
+}
+
+.hud-range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+.hud-range::-moz-range-thumb {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: none;
+  cursor: pointer;
+}
+
+/* ── Responsive ─────────────────────────────────────── */
+
+@media (max-width: 768px) {
+  .hud {
+    height: 60px;
+  }
+
+  .hud-panel--left,
+  .hud-panel--right {
+    display: none;
+  }
+
+  .hud-panel--center {
+    padding: 8px 12px;
+  }
+
+  .hud-related-strip {
+    display: none;
+  }
+
+  .hud-related-label {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

Three cross-cutting features for kbexplorer:

### 1. Theme System (\src/hooks/useTheme.ts\)
- Dark/light/sepia switching with CSS variables
- Persisted in localStorage (\kbe-theme\)
- Body class applied: \	heme-light\, \	heme-sepia\ (dark is default/no class)

### 2. Keyboard Navigation (\src/hooks/useKeyboardNav.ts\)
- \	\ → cycle theme
- \/\ → overview, \g\ → graph, \Escape\ → back
- \←/→\ → prev/next node in reading view
- Ignores input when focused on form elements

### 3. HUD (\src/components/HUD.tsx\ + \src/styles/hud.css\)
- Fixed 170px bottom bar with three panels
- **Left**: minimap canvas with constellation dots
- **Center**: navigation (MAP button, prev/next, current node info, related nodes strip)
- **Right**: reading tools (theme radio buttons, font size slider, column width slider)
- Hidden on graph view, collapses to 60px on mobile (<768px)
- Font size and column width persisted in localStorage

### Files Changed
- \src/hooks/useTheme.ts\ — new
- \src/hooks/useKeyboardNav.ts\ — new
- \src/components/HUD.tsx\ — new
- \src/styles/hud.css\ — new
- \src/index.css\ — added light/sepia theme variables
- \src/App.tsx\ — integrated hooks and HUD component
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/8" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
