### PR TITLE
fix: font sizer, minimap layout, and constellation overlay

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { Network } from 'vis-network/standalone';
+import { DataSet } from 'vis-data';
 import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
 import { NodeVisual } from './NodeVisual';
+import { getVisNodeConfig } from './NodeVisual';
+import { getNodeDegrees } from '../engine/graph';
 import '../styles/hud.css';
 
 interface HUDProps {
@@ -27,9 +31,12 @@ function readPersisted(key: string, fallback: number): number {
 
 export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const overlayNetworkRef = useRef<Network | null>(null);
 
   const [fontSize, setFontSize] = useState(() => readPersisted('kbe-font-size', 1));
-  const [colWidth, setColWidth] = useState(() => readPersisted('kbe-col-width', 1));
+  const [colWidth, setColWidth] = useState(() => readPersisted('kbe-col-width', 2));
+  const [mapExpanded, setMapExpanded] = useState(false);
 
   const currentNode = currentNodeId
     ? graph.nodes.find(n => n.id === currentNodeId) ?? null
@@ -55,65 +62,228 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDP
     localStorage.setItem('kbe-col-width', String(colWidth));
   }, [colWidth]);
 
-  // Draw minimap
+  // Draw minimap using force-directed positions via a hidden vis-network
+  const minimapPositionsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+
   useEffect(() => {
+    // Compute positions using a temporary off-screen vis-network
+    const tempDiv = document.createElement('div');
+    tempDiv.style.cssText = 'position:absolute;left:-9999px;width:400px;height:280px;';
+    document.body.appendChild(tempDiv);
+
+    const degrees = getNodeDegrees(graph);
+    const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
+
+    const nodeData = graph.nodes.map(n => {
+      const deg = degrees.get(n.id) ?? 0;
+      const size = Math.min(10 + deg * 3, 30);
+      const color = clusterColorMap.get(n.cluster) ?? '#888';
+      return {
+        id: n.id,
+        label: '',
+        size,
+        color: { background: color + '88', border: color },
+        borderWidth: 1,
+      };
+    });
+
+    const edgeData = graph.edges.map((e, i) => ({
+      id: `e${i}`,
+      from: e.from,
+      to: e.to,
+    }));
+
+    const nodes = new DataSet(nodeData);
+    const edges = new DataSet(edgeData);
+
+    const net = new Network(tempDiv, { nodes, edges }, {
+      physics: {
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -40,
+          centralGravity: 0.02,
+          springLength: 60,
+          springConstant: 0.08,
+          damping: 0.5,
+        },
+        stabilization: { iterations: 200 },
+      },
+      interaction: { dragNodes: false, zoomView: false, dragView: false },
+    });
+
+    net.once('stabilized', () => {
+      const positions = net.getPositions();
+      const posMap = new Map<string, { x: number; y: number }>();
+      for (const [id, pos] of Object.entries(positions)) {
+        posMap.set(id, pos as { x: number; y: number });
+      }
+      minimapPositionsRef.current = posMap;
+      net.destroy();
+      document.body.removeChild(tempDiv);
+      drawMinimap();
+    });
+
+    return () => {
+      try { net.destroy(); } catch { /* already destroyed */ }
+      try { document.body.removeChild(tempDiv); } catch { /* already removed */ }
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [graph]);
+
+  const drawMinimap = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
+    const posMap = minimapPositionsRef.current;
+    if (posMap.size === 0) return;
 
     const dpr = window.devicePixelRatio || 1;
-    canvas.width = 200 * dpr;
-    canvas.height = 140 * dpr;
+    const W = 200, H = 140;
+    canvas.width = W * dpr;
+    canvas.height = H * dpr;
     ctx.scale(dpr, dpr);
-    ctx.clearRect(0, 0, 200, 140);
+    ctx.clearRect(0, 0, W, H);
 
-    const nodes = graph.nodes;
-    if (nodes.length === 0) return;
+    // Compute bounding box
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const pos of posMap.values()) {
+      minX = Math.min(minX, pos.x); maxX = Math.max(maxX, pos.x);
+      minY = Math.min(minY, pos.y); maxY = Math.max(maxY, pos.y);
+    }
+    const rangeX = maxX - minX || 1;
+    const rangeY = maxY - minY || 1;
+    const pad = 12;
+    const scale = Math.min((W - pad * 2) / rangeX, (H - pad * 2) / rangeY);
 
-    // Deterministic layout: hash-based positioning
-    const positions = nodes.map((n, i) => {
-      const angle = (i / nodes.length) * Math.PI * 2;
-      const radius = 45 + (i % 3) * 12;
-      return {
-        x: 100 + Math.cos(angle) * radius,
-        y: 70 + Math.sin(angle) * radius,
-        node: n,
-      };
-    });
-
-    const posMap = new Map(positions.map(p => [p.node.id, p]));
+    function toCanvas(x: number, y: number): [number, number] {
+      return [
+        pad + (x - minX) * scale + ((W - pad * 2) - rangeX * scale) / 2,
+        pad + (y - minY) * scale + ((H - pad * 2) - rangeY * scale) / 2,
+      ];
+    }
 
     // Draw edges
-    ctx.strokeStyle = 'rgba(255, 255, 255, 0.08)';
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.06)';
     ctx.lineWidth = 0.5;
     for (const edge of graph.edges) {
       const from = posMap.get(edge.from);
       const to = posMap.get(edge.to);
       if (from && to) {
+        const [fx, fy] = toCanvas(from.x, from.y);
+        const [tx, ty] = toCanvas(to.x, to.y);
         ctx.beginPath();
-        ctx.moveTo(from.x, from.y);
-        ctx.lineTo(to.x, to.y);
+        ctx.moveTo(fx, fy);
+        ctx.lineTo(tx, ty);
         ctx.stroke();
       }
     }
 
     // Draw nodes
     const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
-    for (const p of positions) {
-      const color = clusterColorMap.get(p.node.cluster) ?? '#888';
-      const isCurrent = p.node.id === currentNodeId;
+    for (const node of graph.nodes) {
+      const pos = posMap.get(node.id);
+      if (!pos) continue;
+      const [cx, cy] = toCanvas(pos.x, pos.y);
+      const isCurrent = node.id === currentNodeId;
+      const color = clusterColorMap.get(node.cluster) ?? '#888';
       ctx.beginPath();
-      ctx.arc(p.x, p.y, isCurrent ? 4 : 2.5, 0, Math.PI * 2);
+      ctx.arc(cx, cy, isCurrent ? 4 : 2.5, 0, Math.PI * 2);
       ctx.fillStyle = isCurrent ? '#E8C350' : color;
       ctx.fill();
       if (isCurrent) {
         ctx.strokeStyle = '#E8C350';
-        ctx.lineWidth = 1;
+        ctx.lineWidth = 1.5;
         ctx.stroke();
       }
     }
   }, [graph, currentNodeId]);
+
+  // Redraw minimap when current node changes
+  useEffect(() => { drawMinimap(); }, [drawMinimap]);
+
+  // Expanded map overlay (vis-network instance)
+  useEffect(() => {
+    if (!mapExpanded || !overlayRef.current) return;
+
+    const degrees = getNodeDegrees(graph);
+    const clusterColorMap = new Map(graph.clusters.map(c => [c.id, c.color]));
+
+    const nodeData = graph.nodes.map(n => {
+      const deg = degrees.get(n.id) ?? 0;
+      const size = Math.min(18 + deg * 4, 45);
+      const color = clusterColorMap.get(n.cluster) ?? '#9A8A78';
+      const visConfig = getVisNodeConfig(n, config.visuals.mode, config.source, color, size);
+      return {
+        id: n.id,
+        label: n.title,
+        title: `${n.title}\n${deg} connection${deg === 1 ? '' : 's'}`,
+        font: { color: '#C8B8A8', face: 'General Sans, sans-serif', size: 11, strokeWidth: 3, strokeColor: '#0D0D0D' },
+        ...visConfig,
+      };
+    });
+
+    const edgeData = graph.edges.map((e, i) => ({
+      id: `e${i}`,
+      from: e.from,
+      to: e.to,
+      title: e.description,
+      color: { color: '#2A2620', hover: '#4A4438', highlight: '#4A4438' },
+      width: 1,
+      dashes: [3, 5],
+    }));
+
+    const nodes = new DataSet(nodeData);
+    const edges = new DataSet(edgeData);
+
+    const net = new Network(overlayRef.current, { nodes, edges }, {
+      physics: {
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -60,
+          centralGravity: 0.015,
+          springLength: 100,
+          springConstant: 0.08,
+          damping: 0.4,
+        },
+        stabilization: { iterations: 200 },
+      },
+      interaction: {
+        hover: true,
+        tooltipDelay: 200,
+        navigationButtons: false,
+        keyboard: false,
+        dragView: true,
+        zoomView: true,
+      },
+      edges: {
+        smooth: { enabled: true, type: 'continuous', roundness: 0.5 },
+      },
+    });
+
+    net.on('click', (params: { nodes: string[] }) => {
+      if (params.nodes.length > 0) {
+        setMapExpanded(false);
+        window.location.hash = `/node/${encodeURIComponent(params.nodes[0])}`;
+      }
+    });
+
+    // Highlight current node
+    if (currentNodeId) {
+      net.once('stabilized', () => {
+        net.selectNodes([currentNodeId]);
+        net.focus(currentNodeId, { scale: 1.2, animation: { duration: 400, easingFunction: 'easeInOutQuad' } });
+      });
+    }
+
+    overlayNetworkRef.current = net;
+
+    return () => {
+      net.destroy();
+      overlayNetworkRef.current = null;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mapExpanded, graph, config]);
 
   const navigateTo = useCallback((hash: string) => {
     window.location.hash = hash;
@@ -132,117 +302,138 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDP
   };
 
   return (
-    <div className="hud">
-      {/* ── Left: Minimap ─── */}
-      <div className="hud-panel hud-panel--left">
-        <canvas
-          ref={canvasRef}
-          className="hud-minimap"
-          width={200}
-          height={140}
-          onClick={() => navigateTo('#/graph')}
-          title="Open graph view"
-        />
-      </div>
-
-      {/* ── Center: Navigation ─── */}
-      <div className="hud-panel hud-panel--center">
-        <div className="hud-nav-row">
-          <button className="hud-btn" onClick={() => navigateTo('#/graph')}>MAP</button>
-          <button
-            className="hud-btn hud-btn--nav"
-            onClick={goPrev}
-            disabled={!currentNode}
-            title="Previous node (←)"
-          >◀</button>
-          {currentNode ? (
-            <div className="hud-current-node">
-              <span style={{ fontSize: 20 }}>{currentNode.emoji ?? '📌'}</span>
-              <span className="hud-current-title">{currentNode.title}</span>
-              <span className="hud-current-cluster">{currentNode.cluster}</span>
+    <>
+      {/* ── Constellation overlay (expanded minimap) ─── */}
+      {mapExpanded && (
+        <div className="hud-overlay" onClick={(e) => { if (e.target === e.currentTarget) setMapExpanded(false); }}>
+          <div className="hud-overlay-inner">
+            <div className="hud-overlay-header">
+              <span className="hud-overlay-title">Constellation</span>
+              <button className="hud-overlay-close" onClick={() => setMapExpanded(false)}>×</button>
             </div>
-          ) : (
-            <span className="hud-placeholder">Click any node to begin reading</span>
-          )}
-          <button
-            className="hud-btn hud-btn--nav"
-            onClick={goNext}
-            disabled={!currentNode}
-            title="Next node (→)"
-          >▶</button>
+            <div className="hud-overlay-legend">
+              {graph.clusters.map(c => (
+                <span key={c.id} className="hud-overlay-legend-item">
+                  <span className="hud-overlay-legend-dot" style={{ background: c.color }} />
+                  {c.name}
+                </span>
+              ))}
+            </div>
+            <div ref={overlayRef} className="hud-overlay-graph" />
+          </div>
+        </div>
+      )}
+
+      <div className="hud">
+        {/* ── Left: Minimap ─── */}
+        <div className="hud-panel hud-panel--left">
+          <canvas
+            ref={canvasRef}
+            className="hud-minimap"
+            width={200}
+            height={140}
+            onClick={() => setMapExpanded(true)}
+            title="Expand constellation"
+          />
+          <span className="hud-minimap-label">MAP</span>
         </div>
 
-        <div className="hud-nav-row" style={{ alignItems: 'flex-start' }}>
-          <span className="hud-related-label">Related</span>
-          <div className="hud-related-strip">
-            {relatedNodes.length > 0 ? (
-              relatedNodes.map(n => (
-                <a
-                  key={n.id}
-                  className="hud-related-card"
-                  href={`#/node/${encodeURIComponent(n.id)}`}
-                >
-                  <NodeVisual
-                    node={n}
-                    mode={config.visuals.mode}
-                    surface="hud-thumb"
-                    source={config.source}
-                  />
-                  <span className="hud-related-title">{n.title}</span>
-                </a>
-              ))
-            ) : currentNode ? (
-              <span className="hud-placeholder" style={{ fontSize: '0.78rem' }}>No related nodes</span>
-            ) : null}
+        {/* ── Center: Navigation ─── */}
+        <div className="hud-panel hud-panel--center">
+          <div className="hud-nav-row">
+            <button className="hud-btn" onClick={() => setMapExpanded(true)}>MAP</button>
+            <button
+              className="hud-btn hud-btn--nav"
+              onClick={goPrev}
+              disabled={!currentNode}
+              title="Previous node (←)"
+            >◀</button>
+            {currentNode ? (
+              <div className="hud-current-node">
+                <span style={{ fontSize: 20 }}>{currentNode.emoji ?? '📌'}</span>
+                <span className="hud-current-title">{currentNode.title}</span>
+                <span className="hud-current-cluster">{currentNode.cluster}</span>
+              </div>
+            ) : (
+              <span className="hud-placeholder">Click any node to begin reading</span>
+            )}
+            <button
+              className="hud-btn hud-btn--nav"
+              onClick={goNext}
+              disabled={!currentNode}
+              title="Next node (→)"
+            >▶</button>
+          </div>
+
+          <div className="hud-nav-row" style={{ alignItems: 'flex-start' }}>
+            <span className="hud-related-label">Related</span>
+            <div className="hud-related-strip">
+              {relatedNodes.length > 0 ? (
+                relatedNodes.map(n => (
+                  <a
+                    key={n.id}
+                    className="hud-related-card"
+                    href={`#/node/${encodeURIComponent(n.id)}`}
+                  >
+                    <NodeVisual
+                      node={n}
+                      mode={config.visuals.mode}
+                      surface="hud-thumb"
+                      source={config.source}
+                    />
+                    <span className="hud-related-title">{n.title}</span>
+                  </a>
+                ))
+              ) : currentNode ? (
+                <span className="hud-placeholder" style={{ fontSize: '0.78rem' }}>No related nodes</span>
+              ) : null}
+            </div>
+          </div>
+        </div>
+
+        {/* ── Right: Reading Tools ─── */}
+        <div className="hud-panel hud-panel--right">
+          <div className="hud-tool-row">
+            <span className="hud-tool-label">Theme</span>
+            {(['dark', 'light', 'sepia'] as Theme[]).map(t => (
+              <button
+                key={t}
+                className={`hud-theme-btn hud-theme-btn--${t} ${theme === t ? 'hud-theme-btn--active' : ''}`}
+                onClick={() => onThemeChange(t)}
+                title={t}
+              />
+            ))}
+          </div>
+
+          <div className="hud-tool-row">
+            <span className="hud-tool-label">Aa</span>
+            <input
+              type="range"
+              className="hud-range"
+              min={0}
+              max={4}
+              step={1}
+              value={fontSize}
+              onChange={e => setFontSize(Number(e.target.value))}
+              title={`Font size: ${FONT_SIZES[fontSize]}rem`}
+            />
+          </div>
+
+          <div className="hud-tool-row">
+            <span className="hud-tool-label">↔</span>
+            <input
+              type="range"
+              className="hud-range"
+              min={0}
+              max={4}
+              step={1}
+              value={colWidth}
+              onChange={e => setColWidth(Number(e.target.value))}
+              title={`Column width: ${COL_WIDTHS[colWidth]}px`}
+            />
           </div>
         </div>
       </div>
-
-      {/* ── Right: Reading Tools ─── */}
-      <div className="hud-panel hud-panel--right">
-        {/* Theme switcher */}
-        <div className="hud-tool-row">
-          <span className="hud-tool-label">Theme</span>
-          {(['dark', 'light', 'sepia'] as Theme[]).map(t => (
-            <button
-              key={t}
-              className={`hud-theme-btn hud-theme-btn--${t} ${theme === t ? 'hud-theme-btn--active' : ''}`}
-              onClick={() => onThemeChange(t)}
-              title={t}
-            />
-          ))}
-        </div>
-
-        {/* Font size */}
-        <div className="hud-tool-row">
-          <span className="hud-tool-label">Font</span>
-          <input
-            type="range"
-            className="hud-range"
-            min={0}
-            max={4}
-            step={1}
-            value={fontSize}
-            onChange={e => setFontSize(Number(e.target.value))}
-            title={`Font size: ${FONT_SIZES[fontSize]}rem`}
-          />
-        </div>
-
-        {/* Column width */}
-        <div className="hud-tool-row">
-          <span className="hud-tool-label">Width</span>
-          <input
-            type="range"
-            className="hud-range"
-            min={0}
-            max={4}
-            step={1}
-            value={colWidth}
-            onChange={e => setColWidth(Number(e.target.value))}
-            title={`Column width: ${COL_WIDTHS[colWidth]}px`}
-          />
-        </div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -319,3 +319,104 @@ body.theme-light .hud-related-card:hover {
     display: none;
   }
 }
+
+/* ── Minimap label ──────────────────────────────────── */
+
+.hud-minimap-label {
+  font-size: 0.65rem;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-family: var(--font-mono);
+  margin-top: 4px;
+}
+
+/* ── Constellation overlay (expanded minimap) ───────── */
+
+.hud-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  animation: overlayFadeIn 0.25s ease-out;
+}
+
+@keyframes overlayFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.hud-overlay-inner {
+  width: 90vw;
+  height: 80vh;
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  background: rgba(13, 13, 13, 0.6);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.hud-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.hud-overlay-title {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+  color: var(--fg);
+}
+
+.hud-overlay-close {
+  background: none;
+  border: none;
+  color: var(--fg-muted);
+  font-size: 1.5rem;
+  cursor: pointer;
+  padding: 0 4px;
+  line-height: 1;
+}
+
+.hud-overlay-close:hover {
+  color: var(--fg);
+}
+
+.hud-overlay-legend {
+  display: flex;
+  gap: 16px;
+  padding: 8px 20px;
+  flex-wrap: wrap;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+.hud-overlay-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.75rem;
+  color: var(--fg-muted);
+}
+
+.hud-overlay-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.hud-overlay-graph {
+  flex: 1;
+  min-height: 0;
+}

--- a/src/styles/reading.css
+++ b/src/styles/reading.css
@@ -84,7 +84,7 @@
 /* ── Prose ────────────────────────────────────────────── */
 .kb-prose {
   max-width: var(--prose-max-width, 780px);
-  font-size: 1.05rem;
+  font-size: var(--prose-font-size, 1.05rem);
   line-height: 1.7;
   color: var(--fg);
 }

--- a/src/views/GraphView.tsx
+++ b/src/views/GraphView.tsx
@@ -84,7 +84,7 @@ export default function GraphView({ graph, config }: GraphViewProps) {
         id: n.id,
         label: n.title,
         title: `${n.title}\n${deg} connection${deg === 1 ? '' : 's'}`,
-        font: { color: '#C8B8A8', face: 'General Sans', size: 12 },
+        font: { color: '#C8B8A8', face: 'General Sans, sans-serif', size: 12, strokeWidth: 3, strokeColor: '#0D0D0D' },
         ...visConfig,
       };
     });
@@ -107,13 +107,13 @@ export default function GraphView({ graph, config }: GraphViewProps) {
       physics: {
         solver: 'forceAtlas2Based',
         forceAtlas2Based: {
-          gravitationalConstant: -80,
-          centralGravity: 0.01,
-          springLength: 120,
-          springConstant: 0.08,
+          gravitationalConstant: -120,
+          centralGravity: 0.008,
+          springLength: 180,
+          springConstant: 0.04,
           damping: 0.4,
         },
-        stabilization: { iterations: 150 },
+        stabilization: { iterations: 250 },
       },
       interaction: {
         hover: true,


### PR DESCRIPTION
Fixes four issues:

1. **Font sizer broken** — .kb-prose was hardcoding font-size: 1.05rem, ignoring the CSS variable
2. **Width sizer partly broken** — now properly consumed
3. **Minimap layout wrong** — was using naive circular layout, now uses force-directed positions from a temp vis-network
4. **Minimap click wrong** — was navigating to #/graph, now expands a constellation overlay (like Mukaase)

Also improved full-page graph readability: more spacing, font stroke on labels.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/19" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
