### PR TITLE
fix: theme toggle + title layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,9 +51,8 @@ function useIsGraphRoute(): boolean {
   return isGraph;
 }
 
-function Explorer() {
+function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useTheme').ThemeMode; setThemeMode: (t: import('./hooks/useTheme').ThemeMode) => void }) {
   const state = useKnowledgeBase();
-  const [themeMode, , setThemeMode] = useTheme();
   const currentNodeId = useCurrentNodeId();
   const isGraph = useIsGraphRoute();
 
@@ -90,12 +89,12 @@ function Explorer() {
 }
 
 function App() {
-  const [, fluentTheme] = useTheme();
+  const [themeMode, fluentTheme, setThemeMode] = useTheme();
 
   return (
     <FluentProvider theme={fluentTheme} style={{ height: '100%' }}>
       <HashRouter>
-        <Explorer />
+        <Explorer themeMode={themeMode} setThemeMode={setThemeMode} />
       </HashRouter>
     </FluentProvider>
   );

--- a/src/views/OverviewView.tsx
+++ b/src/views/OverviewView.tsx
@@ -45,11 +45,17 @@ const useStyles = makeStyles({
     marginLeft: 'auto',
     marginRight: 'auto',
   },
+  title: {
+    display: 'block',
+    marginBottom: tokens.spacingVerticalS,
+  },
   subtitle: {
+    display: 'block',
     color: tokens.colorNeutralForeground3,
     marginBottom: tokens.spacingVerticalS,
   },
   stats: {
+    display: 'block',
     color: tokens.colorNeutralForeground3,
     marginBottom: tokens.spacingVerticalXXL,
   },
@@ -113,7 +119,7 @@ export function OverviewView({ graph, config }: OverviewViewProps) {
 
   return (
     <div className={classes.root}>
-      <Title1 as="h1">{config.title}</Title1>
+      <Title1 as="h1" className={classes.title}>{config.title}</Title1>
       {config.subtitle && (
         <Body1 className={classes.subtitle}>{config.subtitle}</Body1>
       )}


### PR DESCRIPTION
Two fixes:
1. Theme toggle was broken — useTheme called twice (App + Explorer), separate state instances. Fixed by lifting to App and passing down.
2. Title/subtitle/stats were on one line — added display:block + margins via makeStyles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/23" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
