### PR TITLE
feat: sepia reading theme via custom Fluent theme

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -20,6 +20,7 @@ import {
   MapRegular,
   WeatherMoonRegular,
   WeatherSunnyRegular,
+  BookRegular,
 } from '@fluentui/react-icons';
 import type { KBGraph, KBConfig, KBNode, Theme } from '../types';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
@@ -324,7 +325,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDP
     const posMap = minimapPositionsRef.current;
     if (posMap.size === 0) return;
 
-    const edgeColor = theme === 'dark' ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.15)';
+    const edgeColor = theme === 'dark' ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.12)';
     const highlightColor = theme === 'dark' ? HIGHLIGHT_COLOR_DARK : HIGHLIGHT_COLOR_LIGHT;
 
     const dpr = window.devicePixelRatio || 1;
@@ -655,6 +656,13 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange }: HUDP
               icon={<WeatherSunnyRegular />}
               onClick={() => onThemeChange('light')}
               title="Light"
+            />
+            <Button
+              appearance={theme === 'sepia' ? 'primary' : 'subtle'}
+              size="small"
+              icon={<BookRegular />}
+              onClick={() => onThemeChange('sepia')}
+              title="Sepia"
             />
           </div>
 

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -2,17 +2,68 @@ import { useState, useCallback } from 'react';
 import {
   webDarkTheme,
   webLightTheme,
+  createLightTheme,
   type Theme as FluentTheme,
+  type BrandVariants,
 } from '@fluentui/react-components';
 
-export type ThemeMode = 'dark' | 'light';
+export type ThemeMode = 'dark' | 'light' | 'sepia';
 
 const STORAGE_KEY = 'kbe-theme';
+const MODES: ThemeMode[] = ['dark', 'light', 'sepia'];
+
+// Warm amber brand ramp for the sepia reading theme
+const sepiaBrand: BrandVariants = {
+  10: '#1C1308',
+  20: '#2E2010',
+  30: '#422E16',
+  40: '#553C1C',
+  50: '#6A4B22',
+  60: '#7F5B29',
+  70: '#956C30',
+  80: '#A87D3A',
+  90: '#B88E4E',
+  100: '#C79F63',
+  110: '#D4B07A',
+  120: '#E0C192',
+  130: '#EAD1AB',
+  140: '#F2E1C5',
+  150: '#F8EFDF',
+  160: '#FCF7F0',
+};
+
+const sepiaTheme: FluentTheme = {
+  ...createLightTheme(sepiaBrand),
+  // Warm paper-like backgrounds
+  colorNeutralBackground1: '#F5ECD7',
+  colorNeutralBackground2: '#EDE4CC',
+  colorNeutralBackground3: '#E5DBC2',
+  colorNeutralBackground4: '#DDD2B8',
+  colorNeutralBackground5: '#D5C9AE',
+  colorNeutralBackground6: '#CFC3A6',
+  // Warm dark text for contrast
+  colorNeutralForeground1: '#2A2520',
+  colorNeutralForeground2: '#4A4238',
+  colorNeutralForeground3: '#7A7068',
+  colorNeutralForeground4: '#9A8E80',
+  // Card backgrounds
+  colorNeutralCardBackground: '#F8F0DC',
+  colorNeutralCardBackgroundHover: '#FBF5E8',
+  colorNeutralCardBackgroundPressed: '#F0E6CE',
+  // Strokes
+  colorNeutralStroke1: '#D0C4A8',
+  colorNeutralStroke2: '#DDD2B8',
+  colorNeutralStroke3: '#E8DEC8',
+  // Subtle backgrounds
+  colorSubtleBackground: 'transparent',
+  colorSubtleBackgroundHover: '#EDE4CC',
+  colorSubtleBackgroundPressed: '#E5DBC2',
+};
 
 function readStored(): ThemeMode {
   try {
     const v = localStorage.getItem(STORAGE_KEY);
-    if (v === 'light' || v === 'dark') return v;
+    if (v && MODES.includes(v as ThemeMode)) return v as ThemeMode;
   } catch { /* ignore */ }
   return 'dark';
 }
@@ -20,6 +71,7 @@ function readStored(): ThemeMode {
 const THEME_MAP: Record<ThemeMode, FluentTheme> = {
   dark: webDarkTheme,
   light: webLightTheme,
+  sepia: sepiaTheme,
 };
 
 export function useTheme(): [ThemeMode, FluentTheme, (t: ThemeMode) => void] {
@@ -34,5 +86,6 @@ export function useTheme(): [ThemeMode, FluentTheme, (t: ThemeMode) => void] {
 }
 
 export function nextTheme(current: ThemeMode): ThemeMode {
-  return current === 'dark' ? 'light' : 'dark';
+  const i = MODES.indexOf(current);
+  return MODES[(i + 1) % MODES.length];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,7 +45,7 @@ export interface KBEdge {
 export type VisualMode = 'sprites' | 'heroes' | 'emoji' | 'none';
 
 /** Theme preference. */
-export type Theme = 'dark' | 'light';
+export type Theme = 'dark' | 'light' | 'sepia';
 
 /** Content source configuration. */
 export interface SourceConfig {


### PR DESCRIPTION
Adds a warm sepia reading theme built on Fluent 2 using createLightTheme() with a custom amber brand ramp. Overrides neutral background/card/stroke/foreground tokens for a paper-like reading experience. Three-way toggle: dark ↔ light ↔ sepia.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/27" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
