### PR TITLE
fix: homepage curation excludes file/directory nodes

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * Pre-build manifest generator for kbexplorer local mode.
  *
@@ -458,7 +456,8 @@ export function generateManifest(root = hostRoot) {
 }
 
 // Run if called directly
-if (import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}` ||
-    process.argv[1]?.endsWith('generate-manifest.js')) {
+if (process.argv[1] &&
+    (import.meta.url === `file:///${process.argv[1].replace(/\\/g, '/')}` ||
+     process.argv[1].endsWith('generate-manifest.js'))) {
   generateManifest();
 }

--- a/src/engine/providers/authored-provider.ts
+++ b/src/engine/providers/authored-provider.ts
@@ -18,6 +18,7 @@ export class AuthoredProvider implements GraphProvider {
     private nodemapRaw?: string | null,
     private nodemapFiles?: Record<string, string>,
     private nodemapDirs?: Record<string, Array<{ path: string; type: 'blob' | 'tree'; size?: number }>>,
+    private listFiles?: (pattern: string) => Promise<string[]>,
   ) {}
 
   async resolve(_config: KBConfig, _existingNodes: KBNode[]): Promise<ProviderResult> {
@@ -51,7 +52,7 @@ export class AuthoredProvider implements GraphProvider {
       const nodemapNodes = await loadNodeMap(
         this.nodemapRaw,
         readFile,
-        undefined, // listFiles (glob) not needed for pre-fetched content
+        this.listFiles,
         listDirectory,
       );
 

--- a/src/views/HomePage.tsx
+++ b/src/views/HomePage.tsx
@@ -256,16 +256,24 @@ function NodeCard({ node, config, onClick }: { node: KBNode; config: KBConfig; o
   )
 }
 
-/** Pick curated nodes: hub neighbors + highest-degree + external */
+/** Pick curated nodes: content-first, cluster-diverse, external included */
 function getCuratedNodes(graph: KBGraph): KBNode[] {
   const picked = new Set<string>()
   const result: KBNode[] = []
 
-  // Key content nodes by cluster variety
+  // Filter to curate-worthy nodes (authored content, derived, external — not raw files/dirs/issues/PRs)
+  const curatable = graph.nodes.filter(n => {
+    if (n.source.type === 'file') return false
+    if (n.source.type === 'issue' || n.source.type === 'pull_request' || n.source.type === 'commit') return false
+    if (n.id === 'readme' || n.id === 'repo-root' || n.id === 'commits') return false
+    if (n.source.type === 'section') return false
+    return true
+  })
+
+  // Group by cluster
   const byCluster = new Map<string, KBNode[]>()
-  for (const n of graph.nodes) {
-    if (n.source.type === 'issue' || n.source.type === 'pull_request' || n.source.type === 'commit') continue
-    if (n.id === 'readme' || n.id === 'repo-root' || n.id === 'commits') continue
+  for (const n of curatable) {
+    if (n.source.type === 'external') continue // handled separately
     const list = byCluster.get(n.cluster) ?? []
     list.push(n)
     byCluster.set(n.cluster, list)


### PR DESCRIPTION
Curated picks now only show authored/derived content nodes — no raw file paths or directories. Sections, issues, PRs also excluded from the landing cards.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
