### PR TITLE
feat: homepage as graph node with narrative prose

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -1,0 +1,69 @@
+---
+title: Welcome to kbexplorer
+emoji: Home
+cluster: guide
+display: homepage
+connections:
+  - to: readme
+    type: references
+    description: Repository README
+  - to: graph-engine
+    type: references
+    description: Core graph engine
+  - to: graph-network
+    type: references
+    description: Constellation visualization
+  - to: hud
+    type: references
+    description: HUD & navigation
+  - to: content-pipeline
+    type: references
+    description: Content processing
+  - to: overview-view
+    type: references
+    description: Card overview
+  - to: reading-view
+    type: references
+    description: Deep-dive reading
+  - to: wiki-knowledge-graph
+    type: references
+    description: What is a knowledge graph?
+  - to: local-loader
+    type: references
+    description: Provider pipeline
+  - to: design-decisions
+    type: references
+    description: Design philosophy
+---
+
+Every codebase tells a story. Not in its README — those are written once and forgotten. The real story lives in the spaces between: in the issue that sparked a three-week refactor, in the pull request where two approaches collided and a third emerged, in the commit message that says "finally" after twelve attempts.
+
+**kbexplorer** makes that story navigable.
+
+Point it at any GitHub repository and it transforms the raw material of software development — source files, issues, pull requests, commits, and documentation — into an interconnected [knowledge graph](wiki-knowledge-graph). Not a flat wiki. Not a search index. A *constellation* where every node connects to the things that give it meaning.
+
+## Three ways to explore
+
+The [constellation graph](graph-network) is the signature view — a [force-directed](wiki-force-directed-graph-drawing) visualization where nodes cluster by theme and edges reveal relationships you didn't know existed. Zoom in on a cluster of authentication issues and discover they all reference the same three source files. Follow an edge from a design decision to the PR that implemented it.
+
+The [reading view](reading-view) is for depth. Click any node and its full content unfolds — markdown rendered with inline links that connect you to every other node it touches. Related nodes appear in the sidebar. You're never more than one click from context.
+
+The [card overview](overview-view) is for breadth. Every node as a card, grouped by cluster, scannable at a glance. When you need to answer "what's in this knowledge base?" — start here.
+
+## What powers it
+
+Under the surface, a [provider pipeline](local-loader) pulls data from multiple sources and merges it into a unified graph. The [GitHub provider](github-api) fetches issues, PRs, and source trees. The [authored provider](content-pipeline) processes markdown content with YAML frontmatter. External providers bring in knowledge from beyond the repo — [Wikipedia articles](wiki-knowledge-graph), organizational charts, or any data source you wire up.
+
+The [graph engine](graph-engine) builds edges from inline links, cross-references, and structural relationships. The [HUD](hud) gives you layer toggles, cluster collapse, a detail slider from 1 to 100 nodes, and multi-tier edge importance that fades distant connections while keeping your neighborhood sharp.
+
+## Why graphs, not wikis
+
+A wiki is a tree. You start at the root and drill down. If the page you need isn't where you expected it, you search — and searching means you already know what you're looking for.
+
+A graph is different. Graphs reward *wandering*. You start at one node, follow an interesting edge, and arrive somewhere you didn't expect but needed to find. The structure of the graph — which things connect to which — *is* the knowledge. Reachability matters more than hierarchy.
+
+That's why kbexplorer enforces [graph constraints](design-decisions): no orphan nodes, every node within three hops of the hub, edges typed and weighted so the constellation isn't just a hairball but a legible map of how ideas relate.
+
+## Start exploring
+
+Pick a cluster chip above, click into a curated node, or open the constellation and wander. The graph is yours to explore.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { HashRouter, Routes, Route, useParams, useLocation } from 'react-router-dom';
+import { HashRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom';
 import { FluentProvider } from '@fluentui/react-components';
 import { useKnowledgeBase } from './hooks/useKnowledgeBase';
 import { useTheme } from './hooks/useTheme';
@@ -8,7 +8,6 @@ import { HUD } from './components/HUD';
 import type { DockPosition } from './components/HUD';
 import { ReadingView } from './views/ReadingView';
 import { OverviewView } from './views/OverviewView';
-import { HomePage } from './views/HomePage';
 import { LoadingScreen } from './components/LoadingScreen';
 import { ErrorScreen } from './components/ErrorScreen';
 import './styles/visuals.css';
@@ -58,10 +57,10 @@ function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useT
     <>
       <div style={paddingStyle}>
         <Routes>
-          <Route path="/" element={<HomePage graph={graph} config={config} />} />
+          <Route path="/" element={<Navigate to="/node/home" replace />} />
           <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
           <Route path="/node/:id" element={<ReadingRoute graph={graph} config={config} />} />
-          <Route path="*" element={<HomePage graph={graph} config={config} />} />
+          <Route path="*" element={<Navigate to="/node/home" replace />} />
         </Routes>
       </div>
       <HUD

--- a/src/components/HomePageWidgets.tsx
+++ b/src/components/HomePageWidgets.tsx
@@ -1,0 +1,265 @@
+/**
+ * HomePageWidgets — stats, clusters, curated picks, and data sources
+ * rendered below the homepage narrative prose.
+ */
+import {
+  makeStyles,
+  tokens,
+  Title2,
+  Body1,
+  Body1Strong,
+  Caption1,
+  Card,
+  CardHeader,
+  Badge,
+  Button,
+} from '@fluentui/react-components'
+import {
+  GridRegular,
+  GlobeRegular,
+  BranchForkRegular,
+  DocumentRegular,
+  CodeRegular,
+  SparkleRegular,
+  MapRegular,
+} from '@fluentui/react-icons'
+import type { KBGraph, KBConfig, KBNode } from '../types'
+import { NodeVisual } from './NodeVisual'
+
+const useStyles = makeStyles({
+  stats: {
+    display: 'flex',
+    justifyContent: 'flex-start',
+    gap: '2.5rem',
+    padding: '1.5rem 0',
+    flexWrap: 'wrap',
+    borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    marginTop: '2rem',
+  },
+  stat: { textAlign: 'center' },
+  statNumber: { fontSize: '1.5rem', fontWeight: 700, lineHeight: 1, marginBottom: '0.2rem' },
+  statLabel: { fontSize: '0.75rem', textTransform: 'uppercase' as const, letterSpacing: '0.1em', opacity: 0.5 },
+
+  section: { padding: '2rem 0' },
+  sectionTitle: { fontSize: '1.3rem', fontWeight: 600, marginBottom: '0.5rem', marginTop: 0, display: 'block' },
+  sectionSub: { opacity: 0.6, marginBottom: '1.5rem', maxWidth: '55ch', marginTop: 0, display: 'block' },
+
+  picksGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+    gap: '0.75rem',
+  },
+  pickCard: {
+    cursor: 'pointer',
+    transition: 'transform 0.2s, box-shadow 0.2s',
+    ':hover': { transform: 'translateY(-2px)', boxShadow: tokens.shadow8 },
+  },
+  pickTitle: { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' },
+
+  clusterRow: { display: 'flex', gap: '0.5rem', flexWrap: 'wrap', marginBottom: '1.5rem' },
+  clusterChip: {
+    display: 'flex', alignItems: 'center', gap: '0.4rem',
+    padding: '0.35rem 1rem', borderRadius: '2rem',
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    cursor: 'pointer', fontSize: '0.85rem',
+    transition: 'all 0.2s',
+    ':hover': { borderColor: tokens.colorNeutralForeground3 },
+  },
+
+  providerCard: {
+    display: 'flex', alignItems: 'center', gap: '1rem',
+    padding: '1rem', borderRadius: tokens.borderRadiusLarge,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    marginBottom: '0.5rem',
+  },
+  providerIcon: { fontSize: '1.5rem', opacity: 0.7 },
+})
+
+function getCuratedNodes(graph: KBGraph): KBNode[] {
+  const picked = new Set<string>()
+  const result: KBNode[] = []
+
+  const curatable = graph.nodes.filter(n => {
+    if (n.source.type === 'file') return false
+    if (n.source.type === 'issue' || n.source.type === 'pull_request' || n.source.type === 'commit') return false
+    if (n.id === 'readme' || n.id === 'repo-root' || n.id === 'commits' || n.id === 'home') return false
+    if (n.source.type === 'section') return false
+    return true
+  })
+
+  const byCluster = new Map<string, KBNode[]>()
+  for (const n of curatable) {
+    if (n.source.type === 'external') continue
+    const list = byCluster.get(n.cluster) ?? []
+    list.push(n)
+    byCluster.set(n.cluster, list)
+  }
+
+  const degree = new Map<string, number>()
+  for (const n of graph.nodes) degree.set(n.id, 0)
+  for (const e of graph.edges) {
+    degree.set(e.from, (degree.get(e.from) ?? 0) + 1)
+    degree.set(e.to, (degree.get(e.to) ?? 0) + 1)
+  }
+
+  for (const [, nodes] of byCluster) {
+    const sorted = nodes.sort((a, b) => (degree.get(b.id) ?? 0) - (degree.get(a.id) ?? 0))
+    for (const n of sorted.slice(0, 2)) {
+      if (!picked.has(n.id)) { picked.add(n.id); result.push(n) }
+    }
+  }
+
+  for (const n of graph.nodes) {
+    if (n.source.type === 'external' && !picked.has(n.id)) { picked.add(n.id); result.push(n) }
+  }
+
+  return result.slice(0, 24)
+}
+
+export function HomePageWidgets({ graph, config }: { graph: KBGraph; config: KBConfig }) {
+  const styles = useStyles()
+  const curatedNodes = getCuratedNodes(graph)
+
+  const clusterCounts = new Map<string, number>()
+  for (const n of graph.nodes) clusterCounts.set(n.cluster, (clusterCounts.get(n.cluster) ?? 0) + 1)
+  const activeClusters = graph.clusters.filter(c => clusterCounts.has(c.id))
+
+  const externalCount = graph.nodes.filter(n => n.source.type === 'external').length
+  const contentCount = graph.nodes.filter(n =>
+    n.source.type === 'authored' || n.source.type === 'derived' || n.source.type === 'readme'
+  ).length
+  const workCount = graph.nodes.filter(n =>
+    n.source.type === 'issue' || n.source.type === 'pull_request'
+  ).length
+
+  const navigate = (hash: string) => { window.location.hash = hash }
+  const internalPicks = curatedNodes.filter(n => n.source.type !== 'external')
+  const externalPicks = curatedNodes.filter(n => n.source.type === 'external')
+
+  return (
+    <>
+      {/* Stats */}
+      <div className={styles.stats}>
+        <div className={styles.stat}>
+          <div className={styles.statNumber}>{graph.nodes.length}</div>
+          <div className={styles.statLabel}>Nodes</div>
+        </div>
+        <div className={styles.stat}>
+          <div className={styles.statNumber}>{graph.edges.length}</div>
+          <div className={styles.statLabel}>Connections</div>
+        </div>
+        <div className={styles.stat}>
+          <div className={styles.statNumber}>{activeClusters.length}</div>
+          <div className={styles.statLabel}>Clusters</div>
+        </div>
+        {externalCount > 0 && (
+          <div className={styles.stat}>
+            <div className={styles.statNumber}>{externalCount}</div>
+            <div className={styles.statLabel}>External</div>
+          </div>
+        )}
+      </div>
+
+      {/* Clusters */}
+      <div className={styles.section}>
+        <div className={styles.clusterRow}>
+          {activeClusters.map(c => (
+            <div key={c.id} className={styles.clusterChip} onClick={() => navigate('#/overview')}>
+              <span style={{ width: 8, height: 8, borderRadius: '50%', background: c.color, flexShrink: 0 }} />
+              <Body1Strong>{c.name}</Body1Strong>
+              <Caption1 style={{ opacity: 0.5 }}>{clusterCounts.get(c.id) ?? 0}</Caption1>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Curated Picks */}
+      <div className={styles.section}>
+        <Title2 className={styles.sectionTitle}>Start Exploring</Title2>
+        <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1rem' }}>
+          <Button appearance="primary" size="medium" icon={<MapRegular />} onClick={() => navigate('#/node/readme')}>
+            Constellation
+          </Button>
+          <Button appearance="outline" size="medium" icon={<GridRegular />} onClick={() => navigate('#/overview')}>
+            All Nodes
+          </Button>
+        </div>
+        <div className={styles.picksGrid}>
+          {internalPicks.slice(0, 9).map(n => {
+            const cluster = config.clusters[n.cluster]
+            const excerpt = n.rawContent?.replace(/^#.*\n/gm, '').replace(/\[([^\]]+)\]\([^)]+\)/g, '$1').trim().slice(0, 100)
+            return (
+              <Card key={n.id} appearance="filled-alternative" className={styles.pickCard}
+                onClick={() => navigate(`#/node/${encodeURIComponent(n.id)}`)}>
+                <CardHeader
+                  image={<NodeVisual node={n} mode={config.visuals.mode} surface="card" source={config.source} />}
+                  header={<Body1Strong className={styles.pickTitle}>{n.title}</Body1Strong>}
+                  description={cluster && (
+                    <Badge appearance="tint" size="small" style={{ background: cluster.color + '22', color: cluster.color, marginTop: 4 }}>
+                      {cluster.name}
+                    </Badge>
+                  )}
+                />
+                {excerpt && <Caption1 style={{ opacity: 0.6, display: 'block', padding: '0 12px 8px' }}>{excerpt}…</Caption1>}
+              </Card>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* External References */}
+      {externalPicks.length > 0 && (
+        <div className={styles.section}>
+          <Title2 className={styles.sectionTitle}>
+            <GlobeRegular style={{ marginRight: 6 }} />
+            External References
+          </Title2>
+          <div className={styles.picksGrid}>
+            {externalPicks.slice(0, 9).map(n => {
+              const excerpt = n.rawContent?.replace(/\[.*?\]\(.*?\)/g, '').trim().slice(0, 100)
+              return (
+                <Card key={n.id} appearance="filled-alternative" className={styles.pickCard}
+                  onClick={() => navigate(`#/node/${encodeURIComponent(n.id)}`)}>
+                  <CardHeader
+                    image={<NodeVisual node={n} mode={config.visuals.mode} surface="card" source={config.source} />}
+                    header={<Body1Strong className={styles.pickTitle}>{n.title}</Body1Strong>}
+                    description={<Badge appearance="tint" size="small" style={{ background: '#79C0FF22', color: '#79C0FF', marginTop: 4 }}>Reference</Badge>}
+                  />
+                  {excerpt && <Caption1 style={{ opacity: 0.6, display: 'block', padding: '0 12px 8px' }}>{excerpt}…</Caption1>}
+                </Card>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Data Sources */}
+      <div className={styles.section}>
+        <Title2 className={styles.sectionTitle}>Data Sources</Title2>
+        <div className={styles.providerCard}>
+          <CodeRegular className={styles.providerIcon} />
+          <div><Body1Strong>Source Code</Body1Strong><Caption1 style={{ display: 'block', opacity: 0.6 }}>Repository files and modules</Caption1></div>
+          <Caption1 style={{ marginLeft: 'auto', opacity: 0.5 }}>{graph.nodes.filter(n => n.source.type === 'file').length}</Caption1>
+        </div>
+        <div className={styles.providerCard}>
+          <DocumentRegular className={styles.providerIcon} />
+          <div><Body1Strong>Documentation</Body1Strong><Caption1 style={{ display: 'block', opacity: 0.6 }}>Authored and derived content</Caption1></div>
+          <Caption1 style={{ marginLeft: 'auto', opacity: 0.5 }}>{contentCount}</Caption1>
+        </div>
+        <div className={styles.providerCard}>
+          <BranchForkRegular className={styles.providerIcon} />
+          <div><Body1Strong>Work Items</Body1Strong><Caption1 style={{ display: 'block', opacity: 0.6 }}>Issues and pull requests</Caption1></div>
+          <Caption1 style={{ marginLeft: 'auto', opacity: 0.5 }}>{workCount}</Caption1>
+        </div>
+        {externalCount > 0 && (
+          <div className={styles.providerCard}>
+            <GlobeRegular className={styles.providerIcon} />
+            <div><Body1Strong>External</Body1Strong><Caption1 style={{ display: 'block', opacity: 0.6 }}>Wikipedia and external sources</Caption1></div>
+            <Caption1 style={{ marginLeft: 'auto', opacity: 0.5 }}>{externalCount}</Caption1>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/src/engine/parser.ts
+++ b/src/engine/parser.ts
@@ -36,6 +36,7 @@ interface AuthoredFrontmatter {
   sprite?: string;
   parent?: string;
   derived?: boolean;
+  display?: import('../types').DisplayMode;
   connections?: Array<{ to: string; description: string }>;
 }
 
@@ -103,6 +104,7 @@ export function parseMarkdownFile(path: string, raw: string): KBNode {
     sprite: fm.sprite,
     parent: fm.parent,
     derived: fm.derived === true,
+    display: fm.display,
     connections,
     source: { type: 'authored', file: path },
   };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 /** Core data types for the kbexplorer knowledge graph. */
 
-export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram';
+export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage';
 
 /** A single entry in nodemap.yaml */
 export interface NodeMapEntry {

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -13,6 +13,7 @@ import {
 } from '@fluentui/react-icons';
 import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
+import { HomePageWidgets } from '../components/HomePageWidgets';
 
 interface ReadingViewProps {
   graph: KBGraph;
@@ -248,7 +249,7 @@ function TableView({ content }: { content: string }) {
   );
 }
 
-function renderContent(node: KBNode, linkedHtml: string) {
+function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config?: KBConfig) {
   switch (node.display) {
     case 'code':
       return <pre className="kb-code-display"><code>{node.rawContent}</code></pre>;
@@ -265,6 +266,13 @@ function renderContent(node: KBNode, linkedHtml: string) {
             Diagram rendering coming soon
           </Caption1>
           <pre className="kb-code-display"><code>{node.rawContent}</code></pre>
+        </div>
+      );
+    case 'homepage':
+      return (
+        <div>
+          <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedHtml }} />
+          {graph && config && <HomePageWidgets graph={graph} config={config} />}
         </div>
       );
     default:
@@ -360,7 +368,7 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
 
       {/* Body: prose + connections */}
       <div className={`${styles.body} kb-reading-body`}>
-        {renderContent(node, linkifyContent(node.content))}
+        {renderContent(node, linkifyContent(node.content), graph, config)}
 
         {/* Child nodes (subfolders, sections) */}
         {(() => {


### PR DESCRIPTION
Pages ARE nodes. The homepage is now content/home.md with \display: homepage\ — narrative prose flows into interactive widgets (stats, clusters, curated picks, external refs, data sources).

Parser now extracts \display\ from frontmatter. \/\ route navigates to \#/node/home\.

176 tests pass, verified with Playwright.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/92" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
