### PR TITLE
feat: constellation hero background for homepage

### DIFF
--- a/src/components/ConstellationHero.tsx
+++ b/src/components/ConstellationHero.tsx
@@ -1,0 +1,78 @@
+/**
+ * ConstellationHero — renders a translucent force-directed graph
+ * behind content as a decorative background. Used by the homepage
+ * display mode and available for any rich node.
+ */
+import { useEffect, useRef } from 'react'
+import { makeStyles, tokens } from '@fluentui/react-components'
+import type { KBGraph } from '../types'
+import { createGraphNetwork } from '../engine/createGraphNetwork'
+
+const useStyles = makeStyles({
+  wrapper: {
+    position: 'relative',
+    overflow: 'hidden',
+    borderRadius: tokens.borderRadiusXLarge,
+    marginBottom: '2rem',
+  },
+  canvas: {
+    position: 'absolute',
+    inset: 0,
+    opacity: 0.3,
+    pointerEvents: 'none',
+  },
+  overlay: {
+    position: 'relative',
+    zIndex: 1,
+    padding: '3rem 2rem 2rem',
+  },
+  glow: {
+    position: 'absolute',
+    borderRadius: '50%',
+    filter: 'blur(100px)',
+    opacity: 0.1,
+    pointerEvents: 'none',
+    zIndex: 0,
+  },
+})
+
+interface ConstellationHeroProps {
+  graph: KBGraph
+  height?: string
+  children?: React.ReactNode
+}
+
+export function ConstellationHero({ graph, height = '35vh', children }: ConstellationHeroProps) {
+  const styles = useStyles()
+  const canvasRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!canvasRef.current) return
+    const { network } = createGraphNetwork({
+      container: canvasRef.current,
+      graph,
+      isDark: true,
+      interactive: false,
+      fitOnStabilize: true,
+      nodeSizeRange: [10, 20],
+      nodeSizeStep: 2,
+      labelMaxLength: 0,
+    })
+    network.once('stabilized', () => {
+      network.setOptions({ physics: { enabled: false } })
+      network.fit({ animation: false })
+    })
+    return () => { try { network.destroy() } catch { /* */ } }
+  }, [graph])
+
+  return (
+    <div className={styles.wrapper} style={{ minHeight: height }}>
+      <div className={styles.glow} style={{ background: '#4A9CC8', width: '40vw', height: '40vw', top: '-30%', left: '-10%' }} />
+      <div className={styles.glow} style={{ background: '#E8A838', width: '35vw', height: '35vw', bottom: '-25%', right: '-5%' }} />
+      <div ref={canvasRef} className={styles.canvas} />
+      <div className={styles.overlay}>
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -14,6 +14,7 @@ import {
 import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
 import { HomePageWidgets } from '../components/HomePageWidgets';
+import { ConstellationHero } from '../components/ConstellationHero';
 
 interface ReadingViewProps {
   graph: KBGraph;
@@ -271,6 +272,18 @@ function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config
     case 'homepage':
       return (
         <div>
+          {graph && (
+            <ConstellationHero graph={graph} height="30vh">
+              <div style={{ textAlign: 'center', color: tokens.colorNeutralForeground1 }}>
+                <h1 style={{ fontSize: 'clamp(1.8rem, 4vw, 2.8rem)', fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 0.5rem' }}>
+                  {node.title}
+                </h1>
+                <p style={{ opacity: 0.7, fontSize: 'clamp(0.9rem, 1.5vw, 1.1rem)', margin: 0 }}>
+                  Explore the knowledge constellation
+                </p>
+              </div>
+            </ConstellationHero>
+          )}
           <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedHtml }} />
           {graph && config && <HomePageWidgets graph={graph} config={config} />}
         </div>
@@ -335,6 +348,7 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
   const cluster = findCluster(config, graph.clusters, node.cluster);
 
   const showHero = mode === 'heroes' && !!node.image;
+  const isHomepage = node.display === 'homepage';
 
   return (
     <div className={styles.root}>
@@ -343,28 +357,32 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
         <NodeVisual node={node} mode={mode} surface="hero" source={source} />
       )}
 
-      {/* Back link */}
-      <div className={styles.backLink}>
-        <Button appearance="subtle" icon={<ArrowLeftRegular />} as="a" href="#/">
-          Home
-        </Button>
-      </div>
+      {/* Back link — hide on homepage (it IS home) */}
+      {!isHomepage && (
+        <div className={styles.backLink}>
+          <Button appearance="subtle" icon={<ArrowLeftRegular />} as="a" href="#/">
+            Home
+          </Button>
+        </div>
+      )}
 
-      {/* Header */}
-      <header className={`${styles.header} ${showHero ? styles.headerHero : ''}`}>
-        <div className={styles.headerVisual}>
-          {!showHero && (mode === 'sprites' && node.sprite) && (
-            <NodeVisual node={node} mode={mode} surface="header" source={source} clusterColor={cluster.color} />
-          )}
-          {!showHero && mode === 'emoji' && node.emoji && (
-            <NodeVisual node={node} mode="emoji" surface="header" source={source} clusterColor={cluster.color} />
-          )}
-        </div>
-        <div className={styles.clusterBadge}>
-          <Badge appearance="tint" color="informative">{cluster.name}</Badge>
-        </div>
-        <Title1>{node.title}</Title1>
-      </header>
+      {/* Header — skip for homepage (ConstellationHero handles it) */}
+      {!isHomepage && (
+        <header className={`${styles.header} ${showHero ? styles.headerHero : ''}`}>
+          <div className={styles.headerVisual}>
+            {!showHero && (mode === 'sprites' && node.sprite) && (
+              <NodeVisual node={node} mode={mode} surface="header" source={source} clusterColor={cluster.color} />
+            )}
+            {!showHero && mode === 'emoji' && node.emoji && (
+              <NodeVisual node={node} mode="emoji" surface="header" source={source} clusterColor={cluster.color} />
+            )}
+          </div>
+          <div className={styles.clusterBadge}>
+            <Badge appearance="tint" color="informative">{cluster.name}</Badge>
+          </div>
+          <Title1>{node.title}</Title1>
+        </header>
+      )}
 
       {/* Body: prose + connections */}
       <div className={`${styles.body} kb-reading-body`}>


### PR DESCRIPTION
Adds ConstellationHero component — translucent force-directed graph background. Homepage display mode uses it, standard header hidden (no duplicate title). Any node can use \display: homepage\ for this treatment. 176 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/94" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
