### PR TITLE
fix: center hero title + CTA buttons + fade gradient

### DIFF
--- a/src/components/ConstellationHero.tsx
+++ b/src/components/ConstellationHero.tsx
@@ -13,24 +13,39 @@ const useStyles = makeStyles({
     position: 'relative',
     overflow: 'hidden',
     borderRadius: tokens.borderRadiusXLarge,
-    marginBottom: '2rem',
+    marginBottom: '1.5rem',
   },
   canvas: {
     position: 'absolute',
     inset: 0,
-    opacity: 0.3,
+    opacity: 0.35,
     pointerEvents: 'none',
   },
   overlay: {
     position: 'relative',
+    zIndex: 2,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '2rem',
+    minHeight: 'inherit',
+  },
+  fade: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '30%',
+    background: 'linear-gradient(to bottom, transparent, var(--colorNeutralBackground1, #1a1a2e))',
     zIndex: 1,
-    padding: '3rem 2rem 2rem',
+    pointerEvents: 'none',
   },
   glow: {
     position: 'absolute',
     borderRadius: '50%',
     filter: 'blur(100px)',
-    opacity: 0.1,
+    opacity: 0.12,
     pointerEvents: 'none',
     zIndex: 0,
   },
@@ -67,9 +82,10 @@ export function ConstellationHero({ graph, height = '35vh', children }: Constell
 
   return (
     <div className={styles.wrapper} style={{ minHeight: height }}>
-      <div className={styles.glow} style={{ background: '#4A9CC8', width: '40vw', height: '40vw', top: '-30%', left: '-10%' }} />
-      <div className={styles.glow} style={{ background: '#E8A838', width: '35vw', height: '35vw', bottom: '-25%', right: '-5%' }} />
+      <div className={styles.glow} style={{ background: '#4A9CC8', width: '40vw', height: '40vw', top: '-20%', left: '10%' }} />
+      <div className={styles.glow} style={{ background: '#E8A838', width: '35vw', height: '35vw', bottom: '-15%', right: '15%' }} />
       <div ref={canvasRef} className={styles.canvas} />
+      <div className={styles.fade} />
       <div className={styles.overlay}>
         {children}
       </div>

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -273,14 +273,22 @@ function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config
       return (
         <div>
           {graph && (
-            <ConstellationHero graph={graph} height="30vh">
-              <div style={{ textAlign: 'center', color: tokens.colorNeutralForeground1 }}>
-                <h1 style={{ fontSize: 'clamp(1.8rem, 4vw, 2.8rem)', fontWeight: 700, letterSpacing: '-0.02em', margin: '0 0 0.5rem' }}>
+            <ConstellationHero graph={graph} height="40vh">
+              <div style={{ textAlign: 'center', color: tokens.colorNeutralForeground1, padding: '4rem 0 2rem' }}>
+                <h1 style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)', fontWeight: 700, letterSpacing: '-0.03em', margin: '0 0 0.75rem', lineHeight: 1.1 }}>
                   {node.title}
                 </h1>
-                <p style={{ opacity: 0.7, fontSize: 'clamp(0.9rem, 1.5vw, 1.1rem)', margin: 0 }}>
+                <p style={{ opacity: 0.65, fontSize: 'clamp(0.95rem, 1.5vw, 1.15rem)', margin: '0 0 1.5rem', maxWidth: '40ch', marginLeft: 'auto', marginRight: 'auto' }}>
                   Explore the knowledge constellation
                 </p>
+                <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+                  <a href="#/node/readme" style={{ padding: '0.5rem 1.5rem', borderRadius: '2rem', background: '#4A9CC8', color: '#fff', textDecoration: 'none', fontWeight: 600, fontSize: '0.9rem' }}>
+                    Explore the Graph
+                  </a>
+                  <a href="#/overview" style={{ padding: '0.5rem 1.5rem', borderRadius: '2rem', border: '1px solid rgba(255,255,255,0.3)', color: '#fff', textDecoration: 'none', fontWeight: 500, fontSize: '0.9rem' }}>
+                    Browse All Nodes
+                  </a>
+                </div>
               </div>
             </ConstellationHero>
           )}


### PR DESCRIPTION
Fixes hero layout: title vertically centered, CTA buttons added, bottom fade gradient for smooth prose transition. 176 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/95" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
