### PR TITLE
fix: restore original homepage hero + narrative prose

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { HUD } from './components/HUD';
 import type { DockPosition } from './components/HUD';
 import { ReadingView } from './views/ReadingView';
 import { OverviewView } from './views/OverviewView';
+import { HomePage } from './views/HomePage';
 import { LoadingScreen } from './components/LoadingScreen';
 import { ErrorScreen } from './components/ErrorScreen';
 import './styles/visuals.css';
@@ -57,10 +58,11 @@ function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useT
     <>
       <div style={paddingStyle}>
         <Routes>
-          <Route path="/" element={<Navigate to="/node/home" replace />} />
+          <Route path="/" element={<HomePage graph={graph} config={config} />} />
+          <Route path="/node/home" element={<HomePage graph={graph} config={config} />} />
           <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
           <Route path="/node/:id" element={<ReadingRoute graph={graph} config={config} />} />
-          <Route path="*" element={<Navigate to="/node/home" replace />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>
       <HUD

--- a/src/components/ConstellationHero.tsx
+++ b/src/components/ConstellationHero.tsx
@@ -14,6 +14,8 @@ const useStyles = makeStyles({
     overflow: 'hidden',
     borderRadius: tokens.borderRadiusXLarge,
     marginBottom: '1.5rem',
+    display: 'flex',
+    flexDirection: 'column',
   },
   canvas: {
     position: 'absolute',
@@ -24,12 +26,12 @@ const useStyles = makeStyles({
   overlay: {
     position: 'relative',
     zIndex: 2,
+    flex: 1,
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
     padding: '2rem',
-    minHeight: 'inherit',
   },
   fade: {
     position: 'absolute',
@@ -68,14 +70,28 @@ export function ConstellationHero({ graph, height = '35vh', children }: Constell
       graph,
       isDark: true,
       interactive: false,
-      fitOnStabilize: true,
-      nodeSizeRange: [10, 20],
+      fitOnStabilize: false,
+      nodeSizeRange: [8, 18],
       nodeSizeStep: 2,
       labelMaxLength: 0,
     })
+    // Override physics to spread nodes across the hero
+    network.setOptions({
+      physics: {
+        solver: 'forceAtlas2Based',
+        forceAtlas2Based: {
+          gravitationalConstant: -200,
+          centralGravity: 0.005,
+          springLength: 300,
+          springConstant: 0.02,
+          damping: 0.5,
+        },
+        stabilization: { enabled: true, iterations: 300 },
+      },
+    })
     network.once('stabilized', () => {
       network.setOptions({ physics: { enabled: false } })
-      network.fit({ animation: false })
+      network.fit({ animation: false, minZoomLevel: 0.3, maxZoomLevel: 0.8 })
     })
     return () => { try { network.destroy() } catch { /* */ } }
   }, [graph])

--- a/src/views/HomePage.tsx
+++ b/src/views/HomePage.tsx
@@ -323,6 +323,19 @@ export function HomePage({ graph, config }: HomePageProps) {
   const heroCanvasRef = useRef<HTMLDivElement>(null)
   const [curatedNodes] = useState(() => getCuratedNodes(graph))
 
+  // Find the home node for its narrative prose
+  const homeNode = graph.nodes.find(n => n.id === 'home')
+  const nodeIds = new Set(graph.nodes.map(n => n.id))
+
+  // Linkify home node content — convert [text](node-id) to hash links
+  const linkedContent = homeNode ? homeNode.content.replace(
+    /<a href="([^"#/][^"]*)">/g,
+    (_match: string, target: string) => {
+      if (nodeIds.has(target)) return `<a href="#/node/${encodeURIComponent(target)}">`
+      return `<a href="${target}">`
+    }
+  ) : ''
+
   // Cluster stats
   const clusterCounts = new Map<string, number>()
   for (const n of graph.nodes) {
@@ -416,6 +429,13 @@ export function HomePage({ graph, config }: HomePageProps) {
           <div className={styles.statLabel}>External Sources</div>
         </div>
       </div>
+
+      {/* ── Narrative Prose ── */}
+      {linkedContent && (
+        <section className={styles.section}>
+          <div className="kb-prose" style={{ maxWidth: '70ch' }} dangerouslySetInnerHTML={{ __html: linkedContent }} />
+        </section>
+      )}
 
       {/* ── Clusters ── */}
       <section className={styles.section}>

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -274,11 +274,11 @@ function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config
         <div>
           {graph && (
             <ConstellationHero graph={graph} height="40vh">
-              <div style={{ textAlign: 'center', color: tokens.colorNeutralForeground1, padding: '4rem 0 2rem' }}>
-                <h1 style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)', fontWeight: 700, letterSpacing: '-0.03em', margin: '0 0 0.75rem', lineHeight: 1.1 }}>
+              <div style={{ textAlign: 'center', color: tokens.colorNeutralForeground1 }}>
+                <h1 style={{ fontSize: 'clamp(2rem, 5vw, 3.5rem)', fontWeight: 700, letterSpacing: '-0.03em', margin: '0 0 0.5rem', lineHeight: 1.1 }}>
                   {node.title}
                 </h1>
-                <p style={{ opacity: 0.65, fontSize: 'clamp(0.95rem, 1.5vw, 1.15rem)', margin: '0 0 1.5rem', maxWidth: '40ch', marginLeft: 'auto', marginRight: 'auto' }}>
+                <p style={{ opacity: 0.65, fontSize: 'clamp(0.95rem, 1.5vw, 1.15rem)', margin: '0 0 1.25rem', maxWidth: '40ch', marginLeft: 'auto', marginRight: 'auto' }}>
                   Explore the knowledge constellation
                 </p>
                 <div style={{ display: 'flex', gap: '0.75rem', justifyContent: 'center', flexWrap: 'wrap' }}>


### PR DESCRIPTION
Restores the original HomePage.tsx hero (which was working fine) instead of the broken ConstellationHero-in-ReadingView approach. Adds narrative prose from content/home.md with linkified inline links between stats and clusters. Both / and /node/home route to HomePage. 176 tests pass, verified with Playwright at 1920x1080.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/96" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
