### PR TITLE
fix: homepage prose respects column width slider

### DIFF
--- a/src/views/HomePage.tsx
+++ b/src/views/HomePage.tsx
@@ -433,7 +433,7 @@ export function HomePage({ graph, config }: HomePageProps) {
       {/* ── Narrative Prose ── */}
       {linkedContent && (
         <section className={styles.section}>
-          <div className="kb-prose" style={{ maxWidth: '70ch' }} dangerouslySetInnerHTML={{ __html: linkedContent }} />
+          <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedContent }} />
         </section>
       )}
 


### PR DESCRIPTION
Removed hardcoded maxWidth: 70ch — prose now uses var(--prose-max-width) from the slider. Verified with Playwright: narrowest setting (50%) → 544px, default (75%) → 816px.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
