### PR TITLE
fix: home node is the graph hub

### DIFF
--- a/src/engine/graph.ts
+++ b/src/engine/graph.ts
@@ -150,8 +150,9 @@ export function getNodeDegrees(graph: KBGraph): Map<string, number> {
   return degrees;
 }
 
-/** Find the hub node — prefer 'readme', then authored 'overview', then most-connected. */
+/** Find the hub node — prefer 'home', then 'readme', then 'overview', then most-connected. */
 export function getHubNodeId(graph: KBGraph): string | null {
+  if (graph.nodes.some(n => n.id === 'home')) return 'home';
   if (graph.nodes.some(n => n.id === 'readme')) return 'readme';
   if (graph.nodes.some(n => n.id === 'overview')) return 'overview';
   const degrees = getNodeDegrees(graph);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -355,15 +355,17 @@ export function trimGraphToLimits(
   for (const [id, d] of degree) {
     if (d > hubDeg) { hubId = id; hubDeg = d }
   }
-  // Prefer readme/overview as hub
-  if (graph.nodes.some(n => n.id === 'readme')) hubId = 'readme'
+  // Prefer home/readme/overview as hub
+  if (graph.nodes.some(n => n.id === 'home')) hubId = 'home'
+  else if (graph.nodes.some(n => n.id === 'readme')) hubId = 'readme'
   else if (graph.nodes.some(n => n.id === 'overview')) hubId = 'overview'
 
   const kept = new Set<string>()
 
-  // 1. Hub + current node
+  // 1. Hub + current node + readme (always visible)
   if (hubId) kept.add(hubId)
   if (currentNodeId && degree.has(currentNodeId)) kept.add(currentNodeId)
+  if (graph.nodes.some(n => n.id === 'readme')) kept.add('readme')
 
   // 2. Current node's 1-hop neighbors
   if (currentNodeId) {


### PR DESCRIPTION
Home node now preferred as hub (home > readme > overview > degree). Both home and readme always kept in trimmed graph. Verified: 40/407 nodes, home visible in constellation.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/99" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
