### PR TITLE
fix: HUD always visible on homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,11 +58,11 @@ function Explorer({ themeMode, setThemeMode }: { themeMode: import('./hooks/useT
     <>
       <div style={paddingStyle}>
         <Routes>
-          <Route path="/" element={<HomePage graph={graph} config={config} />} />
+          <Route path="/" element={<Navigate to="/node/home" replace />} />
           <Route path="/node/home" element={<HomePage graph={graph} config={config} />} />
           <Route path="/overview" element={<OverviewView graph={graph} config={config} />} />
           <Route path="/node/:id" element={<ReadingRoute graph={graph} config={config} />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
+          <Route path="*" element={<Navigate to="/node/home" replace />} />
         </Routes>
       </div>
       <HUD


### PR DESCRIPTION
Root / now redirects to /node/home so HUD renders with all controls (MAP, Cards, theme, dock, font, width sliders). Verified with Playwright: 2 sliders, MAP, Cards all present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
