### PR TITLE
feat: Fluent Icon Gallery — 2,647 searchable icons in the graph

### DIFF
--- a/content/icon-gallery.md
+++ b/content/icon-gallery.md
@@ -1,0 +1,22 @@
+---
+title: Fluent Icon Gallery
+emoji: Grid
+cluster: visual
+display: gallery
+connections:
+  - to: wiki-fluent
+    type: references
+    description: Fluent Design System
+  - to: style-system
+    type: references
+    description: Visual styling
+  - to: node-visual
+    type: references
+    description: Node icon rendering
+---
+
+Browse the complete Fluent UI System Icons library — 2,600+ icon families with multiple sizes and styles. These icons power the node visuals throughout kbexplorer's constellation graph, card views, and reading experience.
+
+Each icon comes in **Regular** and **Filled** styles across sizes from 16px to 48px. Click any icon to see its details, available variants, and metadata.
+
+Search by name, or browse by scrolling. The icons are sorted alphabetically for easy scanning.

--- a/scripts/generate-icon-manifest.js
+++ b/scripts/generate-icon-manifest.js
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * generate-icon-manifest.js — Scans the fluentui-system-icons submodule
+ * and produces a JSON manifest of all icon families with metadata and SVG paths.
+ *
+ * Output: src/generated/icon-manifest.json
+ */
+import { readFileSync, readdirSync, existsSync, writeFileSync, statSync } from 'node:fs'
+import { resolve, dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+const assetsDir = resolve(root, 'fluentui-system-icons', 'assets')
+const outPath = resolve(root, 'src', 'generated', 'icon-manifest.json')
+
+if (!existsSync(assetsDir)) {
+  console.error('[icons] fluentui-system-icons/assets not found')
+  process.exit(1)
+}
+
+console.log('[icons] Scanning icon families...')
+
+const families = []
+
+for (const dir of readdirSync(assetsDir)) {
+  const familyDir = join(assetsDir, dir)
+  if (!statSync(familyDir).isDirectory()) continue
+
+  const metaPath = join(familyDir, 'metadata.json')
+  if (!existsSync(metaPath)) continue
+
+  try {
+    const meta = JSON.parse(readFileSync(metaPath, 'utf8'))
+
+    // Find available SVGs
+    const svgDir = join(familyDir, 'SVG')
+    const svgs = []
+    if (existsSync(svgDir)) {
+      for (const f of readdirSync(svgDir)) {
+        if (f.endsWith('.svg')) {
+          const match = f.match(/ic_fluent_.*?_(\d+)_(regular|filled)\.svg/)
+          if (match) {
+            svgs.push({
+              size: parseInt(match[1]),
+              style: match[2],
+              file: f,
+            })
+          }
+        }
+      }
+    }
+
+    // Read the 24px regular SVG as the representative
+    const repr = svgs.find(s => s.size === 24 && s.style === 'regular')
+      || svgs.find(s => s.style === 'regular')
+      || svgs[0]
+
+    let svgContent = null
+    if (repr) {
+      svgContent = readFileSync(join(svgDir, repr.file), 'utf8')
+    }
+
+    families.push({
+      id: dir.toLowerCase().replace(/\s+/g, '-'),
+      name: meta.name || dir,
+      description: meta.description || '',
+      metaphors: meta.metaphor || [],
+      sizes: (meta.size || []).sort((a, b) => a - b),
+      styles: meta.style || [],
+      variantCount: svgs.length,
+      svg: svgContent,
+    })
+  } catch {
+    // skip malformed entries
+  }
+}
+
+// Sort alphabetically
+families.sort((a, b) => a.name.localeCompare(b.name))
+
+// Group into categories by first letter
+const manifest = {
+  totalFamilies: families.length,
+  totalVariants: families.reduce((sum, f) => sum + f.variantCount, 0),
+  families,
+}
+
+writeFileSync(outPath, JSON.stringify(manifest, null, 2))
+console.log(`[icons] Written ${families.length} families to ${outPath}`)

--- a/src/components/IconGallery.tsx
+++ b/src/components/IconGallery.tsx
@@ -1,0 +1,305 @@
+/**
+ * IconGallery — browseable grid of Fluent UI System Icons.
+ * Lazy-loads icon-manifest.json and renders a searchable, tiled gallery.
+ */
+import { useState, useEffect, useMemo } from 'react'
+import {
+  makeStyles,
+  tokens,
+  SearchBox,
+  Caption1,
+  Body1Strong,
+  Badge,
+  Card,
+  Title2,
+  Subtitle2,
+} from '@fluentui/react-components'
+
+interface IconFamily {
+  id: string
+  name: string
+  description: string
+  metaphors: string[]
+  sizes: number[]
+  styles: string[]
+  variantCount: number
+  svg: string | null
+}
+
+interface IconManifest {
+  totalFamilies: number
+  totalVariants: number
+  families: IconFamily[]
+}
+
+const useStyles = makeStyles({
+  root: {
+    marginTop: '1.5rem',
+  },
+  searchRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1rem',
+    marginBottom: '1.5rem',
+    flexWrap: 'wrap',
+  },
+  stats: {
+    opacity: 0.5,
+    fontSize: '0.85rem',
+  },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+    gap: '0.5rem',
+  },
+  tile: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '1rem 0.5rem',
+    borderRadius: tokens.borderRadiusMedium,
+    border: `1px solid transparent`,
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+    ':hover': {
+      border: `1px solid ${tokens.colorNeutralStroke1}`,
+      backgroundColor: tokens.colorNeutralBackground3,
+      transform: 'scale(1.05)',
+    },
+  },
+  tileSvg: {
+    width: 32,
+    height: 32,
+    marginBottom: '0.5rem',
+    opacity: 0.85,
+  },
+  tileName: {
+    fontSize: '0.65rem',
+    textAlign: 'center',
+    opacity: 0.6,
+    lineHeight: 1.2,
+    maxWidth: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+
+  // Detail overlay
+  detailOverlay: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 1000,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0,0,0,0.6)',
+  },
+  detailCard: {
+    maxWidth: '600px',
+    width: '90vw',
+    maxHeight: '85vh',
+    overflowY: 'auto',
+    padding: '2rem',
+    borderRadius: tokens.borderRadiusXLarge,
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+  },
+  detailHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '1.5rem',
+    marginBottom: '1.5rem',
+  },
+  detailSvgLarge: {
+    width: 80,
+    height: 80,
+    flexShrink: 0,
+  },
+  detailMeta: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.5rem',
+    marginBottom: '1rem',
+  },
+  detailSizes: {
+    display: 'flex',
+    gap: '1.5rem',
+    flexWrap: 'wrap',
+    marginTop: '1rem',
+  },
+  sizePreview: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '0.25rem',
+  },
+
+  loadingMsg: {
+    padding: '3rem',
+    textAlign: 'center',
+    opacity: 0.5,
+  },
+})
+
+// Pagination
+const PAGE_SIZE = 200
+
+export function IconGallery() {
+  const styles = useStyles()
+  const [manifest, setManifest] = useState<IconManifest | null>(null)
+  const [search, setSearch] = useState('')
+  const [selectedIcon, setSelectedIcon] = useState<IconFamily | null>(null)
+  const [page, setPage] = useState(0)
+
+  // Lazy-load the icon manifest
+  useEffect(() => {
+    import('../generated/icon-manifest.json')
+      .then(mod => setManifest((mod.default ?? mod) as IconManifest))
+      .catch(() => setManifest(null))
+  }, [])
+
+  // Filter by search
+  const filtered = useMemo(() => {
+    if (!manifest) return []
+    if (!search.trim()) return manifest.families
+    const q = search.toLowerCase()
+    return manifest.families.filter(f =>
+      f.name.toLowerCase().includes(q) ||
+      f.description.toLowerCase().includes(q) ||
+      f.metaphors.some(m => m.toLowerCase().includes(q))
+    )
+  }, [manifest, search])
+
+  // Paginated slice
+  const visible = filtered.slice(0, (page + 1) * PAGE_SIZE)
+  const hasMore = visible.length < filtered.length
+
+  if (!manifest) {
+    return <div className={styles.loadingMsg}>Loading icon library…</div>
+  }
+
+  return (
+    <div className={styles.root}>
+      {/* Search + stats */}
+      <div className={styles.searchRow}>
+        <SearchBox
+          placeholder="Search icons by name or metaphor…"
+          value={search}
+          onChange={(_e, data) => { setSearch(data.value); setPage(0) }}
+          style={{ flex: 1, maxWidth: 400 }}
+        />
+        <Caption1 className={styles.stats}>
+          {filtered.length === manifest.totalFamilies
+            ? `${manifest.totalFamilies} families · ${manifest.totalVariants} variants`
+            : `${filtered.length} matches`}
+        </Caption1>
+      </div>
+
+      {/* Grid */}
+      <div className={styles.grid}>
+        {visible.map(icon => (
+          <div
+            key={icon.id}
+            className={styles.tile}
+            onClick={() => setSelectedIcon(icon)}
+            title={icon.description || icon.name}
+          >
+            {icon.svg ? (
+              <div
+                className={styles.tileSvg}
+                dangerouslySetInnerHTML={{
+                  __html: icon.svg
+                    .replace(/fill="#\w+"/g, `fill="currentColor"`)
+                    .replace(/width="\d+"/, 'width="32"')
+                    .replace(/height="\d+"/, 'height="32"'),
+                }}
+              />
+            ) : (
+              <div className={styles.tileSvg} style={{ opacity: 0.2 }}>?</div>
+            )}
+            <span className={styles.tileName}>{icon.name}</span>
+          </div>
+        ))}
+      </div>
+
+      {/* Load more */}
+      {hasMore && (
+        <div style={{ textAlign: 'center', padding: '2rem' }}>
+          <Caption1
+            style={{ cursor: 'pointer', opacity: 0.6 }}
+            onClick={() => setPage(p => p + 1)}
+          >
+            Show more ({filtered.length - visible.length} remaining)
+          </Caption1>
+        </div>
+      )}
+
+      {/* Detail overlay */}
+      {selectedIcon && (
+        <div className={styles.detailOverlay} onClick={() => setSelectedIcon(null)}>
+          <Card className={styles.detailCard} onClick={e => e.stopPropagation()}>
+            <div className={styles.detailHeader}>
+              {selectedIcon.svg && (
+                <div
+                  className={styles.detailSvgLarge}
+                  dangerouslySetInnerHTML={{
+                    __html: selectedIcon.svg
+                      .replace(/fill="#\w+"/g, `fill="currentColor"`)
+                      .replace(/width="\d+"/, 'width="80"')
+                      .replace(/height="\d+"/, 'height="80"'),
+                  }}
+                />
+              )}
+              <div>
+                <Title2>{selectedIcon.name}</Title2>
+                {selectedIcon.description && (
+                  <Caption1 style={{ display: 'block', opacity: 0.6, marginTop: 4 }}>
+                    {selectedIcon.description}
+                  </Caption1>
+                )}
+              </div>
+            </div>
+
+            {/* Metaphors */}
+            {selectedIcon.metaphors.length > 0 && (
+              <div className={styles.detailMeta}>
+                {selectedIcon.metaphors.map(m => (
+                  <Badge key={m} appearance="outline" size="medium">{m}</Badge>
+                ))}
+              </div>
+            )}
+
+            {/* Sizes + styles */}
+            <Subtitle2 style={{ marginTop: '1rem', marginBottom: '0.5rem' }}>
+              {selectedIcon.variantCount} variants · {selectedIcon.styles.join(' & ')}
+            </Subtitle2>
+
+            <div className={styles.detailSizes}>
+              {selectedIcon.sizes.map(size => (
+                <div key={size} className={styles.sizePreview}>
+                  {selectedIcon.svg && (
+                    <div
+                      dangerouslySetInnerHTML={{
+                        __html: selectedIcon.svg
+                          .replace(/fill="#\w+"/g, `fill="currentColor"`)
+                          .replace(/width="\d+"/, `width="${size}"`)
+                          .replace(/height="\d+"/, `height="${size}"`),
+                      }}
+                    />
+                  )}
+                  <Caption1 style={{ opacity: 0.5 }}>{size}px</Caption1>
+                </div>
+              ))}
+            </div>
+
+            {/* Close hint */}
+            <Caption1 style={{ display: 'block', textAlign: 'center', opacity: 0.3, marginTop: '1.5rem' }}>
+              Click outside to close
+            </Caption1>
+          </Card>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 /** Core data types for the kbexplorer knowledge graph. */
 
-export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage';
+export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage' | 'gallery' | 'icon-detail';
 
 /** A single entry in nodemap.yaml */
 export interface NodeMapEntry {

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -15,6 +15,7 @@ import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
 import { HomePageWidgets } from '../components/HomePageWidgets';
 import { ConstellationHero } from '../components/ConstellationHero';
+import { IconGallery } from '../components/IconGallery';
 
 interface ReadingViewProps {
   graph: KBGraph;
@@ -294,6 +295,13 @@ function renderContent(node: KBNode, linkedHtml: string, graph?: KBGraph, config
           )}
           <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedHtml }} />
           {graph && config && <HomePageWidgets graph={graph} config={config} />}
+        </div>
+      );
+    case 'gallery':
+      return (
+        <div>
+          <div className="kb-prose" dangerouslySetInnerHTML={{ __html: linkedHtml }} />
+          <IconGallery />
         </div>
       );
     default:


### PR DESCRIPTION
Browse the entire Fluent UI System Icons library as a graph node. Search by name or metaphor, click for detail overlay with all sizes/styles. New \display: gallery\ mode. Verified with Playwright: grid renders, search filters to 40 results, detail overlay shows metadata + size previews.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/101" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
