### PR TITLE
fix: add Dock top button to sidebar layout

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -36,34 +36,32 @@ connections:
     description: Design philosophy
 ---
 
-Every codebase tells a story. Not in its README — those are written once and forgotten. The real story lives in the spaces between: in the issue that sparked a three-week refactor, in the pull request where two approaches collided and a third emerged, in the commit message that says "finally" after twelve attempts.
+Knowledge lives in many places. Source code in one repository, issues in another, design decisions in a document, architectural context in a pull request thread, tribal knowledge in someone's head. Each system of record captures a piece of the truth — but the connections between them are invisible. You can find the issue, but not the PR that resolved it, the files it changed, the Wikipedia concept it implements, or the design decision that motivated it.
 
-**kbexplorer** makes that story navigable.
+**kbexplorer** builds a [knowledge graph](wiki-knowledge-graph) overlay across these isolated islands of information, making the interconnections between them navigable for both humans and agents.
 
-Point it at any GitHub repository and it transforms the raw material of software development — source files, issues, pull requests, commits, and documentation — into an interconnected [knowledge graph](wiki-knowledge-graph). Not a flat wiki. Not a search index. A *constellation* where every node connects to the things that give it meaning.
+## How it works
+
+kbexplorer connects to multiple **node providers** — systems of record like GitHub, authored documentation, Wikipedia, organizational charts — and pulls their data into a unified graph. The [provider pipeline](local-loader) merges nodes from every source, and the [graph engine](graph-engine) discovers relationships: inline references, cross-links, shared identities, structural containment. What emerges is a [constellation](graph-network) where every node connects to the things that give it meaning.
+
+The [GitHub provider](github-api) brings in issues, pull requests, source trees, and commit history. The [authored provider](content-pipeline) processes markdown content with YAML frontmatter. External providers reach beyond the repo — [Wikipedia articles](wiki-knowledge-graph) for conceptual grounding, organizational charts for team structure, or any data source you wire up.
 
 ## Three ways to explore
 
-The [constellation graph](graph-network) is the signature view — a [force-directed](wiki-force-directed-graph-drawing) visualization where nodes cluster by theme and edges reveal relationships you didn't know existed. Zoom in on a cluster of authentication issues and discover they all reference the same three source files. Follow an edge from a design decision to the PR that implemented it.
+The [constellation graph](graph-network) is the signature view — a [force-directed](wiki-force-directed-graph-drawing) visualization where nodes cluster by theme and edges reveal relationships across systems of record. Follow an edge from a design decision to the PR that implemented it to the source files it changed.
 
-The [reading view](reading-view) is for depth. Click any node and its full content unfolds — markdown rendered with inline links that connect you to every other node it touches. Related nodes appear in the sidebar. You're never more than one click from context.
+The [reading view](reading-view) is for depth. Click any node and its full content unfolds — rendered with inline links that connect you to every other node it touches. Related nodes appear in the sidebar. You're never more than one click from context.
 
 The [card overview](overview-view) is for breadth. Every node as a card, grouped by cluster, scannable at a glance. When you need to answer "what's in this knowledge base?" — start here.
 
-## What powers it
+## Why a graph overlay
 
-Under the surface, a [provider pipeline](local-loader) pulls data from multiple sources and merges it into a unified graph. The [GitHub provider](github-api) fetches issues, PRs, and source trees. The [authored provider](content-pipeline) processes markdown content with YAML frontmatter. External providers bring in knowledge from beyond the repo — [Wikipedia articles](wiki-knowledge-graph), organizational charts, or any data source you wire up.
+The value isn't in any single system of record — it's in the connections between them. An issue references a file. A PR closes that issue and modifies three modules. A Wikipedia article explains the algorithm those modules implement. A design decision document captures *why* that algorithm was chosen over alternatives.
 
-The [graph engine](graph-engine) builds edges from inline links, cross-references, and structural relationships. The [HUD](hud) gives you layer toggles, cluster collapse, a detail slider from 1 to 100 nodes, and multi-tier edge importance that fades distant connections while keeping your neighborhood sharp.
+These relationships exist, but they're scattered across tools that don't talk to each other. kbexplorer surfaces them as typed, weighted edges in a navigable graph. The [HUD](hud) gives you layer toggles, cluster collapse, a detail slider, and multi-tier edge importance that fades distant connections while keeping your neighborhood sharp.
 
-## Why graphs, not wikis
-
-A wiki is a tree. You start at the root and drill down. If the page you need isn't where you expected it, you search — and searching means you already know what you're looking for.
-
-A graph is different. Graphs reward *wandering*. You start at one node, follow an interesting edge, and arrive somewhere you didn't expect but needed to find. The structure of the graph — which things connect to which — *is* the knowledge. Reachability matters more than hierarchy.
-
-That's why kbexplorer enforces [graph constraints](design-decisions): no orphan nodes, every node within three hops of the hub, edges typed and weighted so the constellation isn't just a hairball but a legible map of how ideas relate.
+kbexplorer enforces [graph constraints](design-decisions): no orphan nodes, every node within three hops of the hub, edges typed and weighted so the constellation is a legible map — not a hairball.
 
 ## Start exploring
 
-Pick a cluster chip above, click into a curated node, or open the constellation and wander. The graph is yours to explore.
+Pick a cluster chip above, click into a curated node, or open the constellation and follow the edges. The graph is yours to explore.

--- a/e2e/visual-validation.spec.ts
+++ b/e2e/visual-validation.spec.ts
@@ -137,25 +137,17 @@ test.describe('Visual Validation', () => {
     expect(stored).toBe('left')
   })
 
-  test('dock cycles through all positions without refresh', async ({ page }) => {
+  test('dock cycles through all 4 positions without refresh', async ({ page }) => {
     await page.goto('/#/node/readme', { timeout: 60000 })
     await page.waitForTimeout(3000)
 
-    // Start from bottom (has all 4 buttons)
-    await page.getByRole('button', { name: 'Dock bottom' }).click()
-    await page.waitForTimeout(1500)
+    const positions = ['left', 'right', 'bottom', 'top'] as const
+    for (const pos of positions) {
+      await page.getByRole('button', { name: `Dock ${pos}` }).click()
+      await page.waitForTimeout(1500)
 
-    // Bottom → left → right → bottom (sidebar layout only has left/right/bottom)
-    const sequence = ['left', 'right', 'bottom', 'top'] as const
-    for (const pos of sequence) {
-      const btn = page.getByRole('button', { name: `Dock ${pos}` })
-      if (await btn.count() > 0) {
-        await btn.click()
-        await page.waitForTimeout(1500)
-
-        const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
-        expect(stored).toBe(pos)
-      }
+      const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+      expect(stored).toBe(pos)
     }
 
     // Verify HUD is still functional at final position

--- a/e2e/visual-validation.spec.ts
+++ b/e2e/visual-validation.spec.ts
@@ -1,0 +1,413 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('Visual Validation', () => {
+
+  // ── Homepage ──────────────────────────────────────────
+
+  test('homepage renders hero + prose + widgets', async ({ page }) => {
+    await page.goto('/#/node/home', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Hero title
+    const h1 = page.locator('h1')
+    await expect(h1).toBeVisible()
+    await expect(h1).toContainText('kbexplorer')
+
+    // Prose section
+    await expect(page.locator('.kb-prose')).toBeVisible()
+
+    // Stats ribbon (look for node count numbers)
+    const body = await page.textContent('body')
+    expect(body).toMatch(/\d+Nodes/)
+
+    // CTAs — rendered as Fluent Buttons in HomePage
+    const exploreBtn = page.getByRole('button', { name: 'Explore the Graph' })
+    const browseBtn = page.getByRole('button', { name: 'Browse All Nodes' })
+    const hasCtas = (await exploreBtn.count()) > 0 || (await browseBtn.count()) > 0
+    // Also check for anchor-based CTAs
+    const exploreLink = page.locator('a:has-text("Explore the Graph")')
+    const hasLinks = (await exploreLink.count()) > 0
+    expect(hasCtas || hasLinks).toBe(true)
+  })
+
+  // ── HUD Controls ──────────────────────────────────────
+
+  test('HUD has all controls', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // MAP and Cards buttons
+    await expect(page.getByRole('button', { name: 'MAP' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Cards' })).toBeVisible()
+
+    // Dock buttons
+    await expect(page.getByRole('button', { name: 'Dock bottom' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Dock left' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Dock right' })).toBeVisible()
+    await expect(page.getByRole('button', { name: 'Dock top' })).toBeVisible()
+
+    // Theme buttons
+    await expect(page.getByRole('button', { name: /Dark/ })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Light/ })).toBeVisible()
+
+    // Sliders (at least detail + zoom or font + width)
+    const sliders = page.locator('input[type="range"]')
+    expect(await sliders.count()).toBeGreaterThanOrEqual(2)
+  })
+
+  // ── Dock Switching (live) ─────────────────────────────
+
+  test('dock left works without refresh', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    await page.getByRole('button', { name: 'Dock left' }).click()
+    await page.waitForTimeout(2000)
+
+    const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+    expect(stored).toBe('left')
+
+    // Sidebar graph canvas should be visible
+    const canvases = await page.locator('canvas').count()
+    expect(canvases).toBeGreaterThanOrEqual(1)
+
+    // Verify sidebar is on the left side
+    const layout = await page.evaluate(() => {
+      const sidebar = document.querySelector('[class*=expandedContent]') as HTMLElement
+      if (!sidebar) return null
+      const rect = sidebar.getBoundingClientRect()
+      return { left: Math.round(rect.left), right: Math.round(rect.right) }
+    })
+    if (layout) {
+      expect(layout.left).toBeLessThan(50)
+    }
+  })
+
+  test('dock right works without refresh', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    await page.getByRole('button', { name: 'Dock right' }).click()
+    await page.waitForTimeout(2000)
+
+    const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+    expect(stored).toBe('right')
+
+    // Verify the sidebar is on the right side of the viewport
+    const layout = await page.evaluate(() => {
+      const sidebar = document.querySelector('[class*=expandedContent]') as HTMLElement
+      if (!sidebar) return null
+      const rect = sidebar.getBoundingClientRect()
+      return { left: Math.round(rect.left), right: Math.round(rect.right), vpWidth: window.innerWidth }
+    })
+    // Sidebar right edge should be near or at viewport right
+    if (layout) {
+      expect(layout.right).toBeGreaterThan(layout.vpWidth - 50)
+      expect(layout.left).toBeGreaterThan(layout.vpWidth * 0.5)
+    }
+  })
+
+  test('dock bottom works without refresh', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Start from left
+    await page.getByRole('button', { name: 'Dock left' }).click()
+    await page.waitForTimeout(1000)
+
+    // Switch to bottom
+    await page.getByRole('button', { name: 'Dock bottom' }).click()
+    await page.waitForTimeout(2000)
+
+    const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+    expect(stored).toBe('bottom')
+  })
+
+  test('dock persists across reload', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    await page.getByRole('button', { name: 'Dock left' }).click()
+    await page.waitForTimeout(1000)
+
+    await page.reload()
+    await page.waitForTimeout(3000)
+
+    const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+    expect(stored).toBe('left')
+  })
+
+  test('dock cycles through all positions without refresh', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Start from bottom (has all 4 buttons)
+    await page.getByRole('button', { name: 'Dock bottom' }).click()
+    await page.waitForTimeout(1500)
+
+    // Bottom → left → right → bottom (sidebar layout only has left/right/bottom)
+    const sequence = ['left', 'right', 'bottom', 'top'] as const
+    for (const pos of sequence) {
+      const btn = page.getByRole('button', { name: `Dock ${pos}` })
+      if (await btn.count() > 0) {
+        await btn.click()
+        await page.waitForTimeout(1500)
+
+        const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+        expect(stored).toBe(pos)
+      }
+    }
+
+    // Verify HUD is still functional at final position
+    const hudVisible = await page.evaluate(() => {
+      const buttons = [...document.querySelectorAll('button')]
+      return buttons.some(b => b.title?.includes('Dock'))
+    })
+    expect(hudVisible).toBe(true)
+  })
+
+  test('MAP overlay opens and closes', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Open MAP overlay
+    await page.getByRole('button', { name: 'MAP' }).click()
+    await page.waitForTimeout(2000)
+
+    // Overlay should have a canvas and close button
+    const canvases = await page.locator('canvas').count()
+    expect(canvases).toBeGreaterThanOrEqual(1)
+
+    // Close overlay (dismiss button or click outside)
+    const dismissBtn = page.getByRole('button', { name: /Dismiss|Close/ })
+    if (await dismissBtn.count() > 0) {
+      await dismissBtn.click()
+    } else {
+      await page.keyboard.press('Escape')
+    }
+    await page.waitForTimeout(1000)
+  })
+
+  test('collapse and expand HUD', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Find and click collapse button
+    const collapseBtn = page.getByRole('button', { name: 'Collapse' })
+    if (await collapseBtn.count() > 0) {
+      await collapseBtn.click()
+      await page.waitForTimeout(1000)
+
+      // HUD should be collapsed — dock buttons should still be accessible
+      const expandBtn = page.getByRole('button', { name: 'Expand' })
+      await expect(expandBtn).toBeVisible({ timeout: 3000 })
+
+      // Expand it back
+      await expandBtn.click()
+      await page.waitForTimeout(1000)
+
+      // MAP button should be visible again
+      await expect(page.getByRole('button', { name: 'MAP' })).toBeVisible()
+    }
+  })
+
+  // ── Content Node Rendering ────────────────────────────
+
+  test('content node renders with prose + connections', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await expect(page.locator('.kb-prose')).toBeVisible({ timeout: 15000 })
+
+    await expect(page.locator('h1')).toBeVisible({ timeout: 5000 })
+    const h1 = await page.locator('h1').textContent()
+    expect(h1).toBeTruthy()
+
+    // Inline links should be present
+    const links = await page.locator('.kb-prose a').count()
+    expect(links).toBeGreaterThan(0)
+  })
+
+  test('Wikipedia node renders with external link', async ({ page }) => {
+    await page.goto('/#/node/wiki-knowledge-graph', { timeout: 60000 })
+    await page.waitForTimeout(5000)
+
+    const wikiLink = page.locator('a[href*="wikipedia.org"]')
+    await expect(wikiLink).toBeVisible({ timeout: 10000 })
+  })
+
+  // ── Icon Gallery ──────────────────────────────────────
+
+  test('icon gallery renders with search', async ({ page }) => {
+    await page.goto('/#/node/icon-gallery', { timeout: 60000 })
+    await page.waitForTimeout(5000)
+
+    const search = page.getByPlaceholder(/Search icons/)
+    await expect(search).toBeVisible({ timeout: 10000 })
+
+    // Fill search
+    await search.fill('sparkle')
+    await page.waitForTimeout(1000)
+
+    const body = await page.textContent('body')
+    expect(body).toMatch(/\d+ matches/)
+  })
+
+  // ── Overview Cards ────────────────────────────────────
+
+  test('overview page renders cards grouped by cluster', async ({ page }) => {
+    await page.goto('/#/overview', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    const h1 = page.locator('h1')
+    await expect(h1).toBeVisible()
+
+    // Should have cluster sections
+    const body = await page.textContent('body')
+    expect(body).toContain('nodes')
+    expect(body).toContain('edges')
+  })
+
+  // ── Detail Slider ─────────────────────────────────────
+
+  test('detail slider changes visible node count', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+    await page.evaluate(() => localStorage.setItem('kbe-hud-dock', 'left'))
+    await page.reload()
+    await page.waitForTimeout(5000)
+
+    // Read default trim count
+    const body1 = await page.textContent('body')
+    const match1 = body1?.match(/(\d+)\/(\d+) nodes/)
+    expect(match1).toBeTruthy()
+    const defaultShown = parseInt(match1![1])
+    const total = parseInt(match1![2])
+    expect(defaultShown).toBeLessThanOrEqual(40)
+    expect(total).toBeGreaterThan(defaultShown)
+
+    // Change detail to minimum (index 0 = 5 nodes)
+    await page.evaluate(() => localStorage.setItem('kbe-detail', '0'))
+    await page.reload()
+    await page.waitForTimeout(5000)
+
+    const body2 = await page.textContent('body')
+    const match2 = body2?.match(/(\d+)\/(\d+) nodes/)
+    expect(match2).toBeTruthy()
+    const minShown = parseInt(match2![1])
+    expect(minShown).toBeLessThanOrEqual(5)
+    expect(minShown).toBeLessThan(defaultShown)
+
+    // Reset
+    await page.evaluate(() => localStorage.setItem('kbe-detail', '2'))
+  })
+
+  // ── Column Width ──────────────────────────────────────
+
+  test('column width slider changes prose width', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Set narrow
+    await page.evaluate(() => localStorage.setItem('kbe-col-width', '0'))
+    await page.reload()
+    await page.waitForTimeout(3000)
+
+    const narrowWidth = await page.evaluate(() => {
+      const prose = document.querySelector('.kb-prose')
+      return prose ? Math.round(prose.getBoundingClientRect().width) : 0
+    })
+
+    // Set wide
+    await page.evaluate(() => localStorage.setItem('kbe-col-width', '4'))
+    await page.reload()
+    await page.waitForTimeout(3000)
+
+    const wideWidth = await page.evaluate(() => {
+      const prose = document.querySelector('.kb-prose')
+      return prose ? Math.round(prose.getBoundingClientRect().width) : 0
+    })
+
+    expect(narrowWidth).toBeGreaterThan(0)
+    expect(wideWidth).toBeGreaterThan(narrowWidth)
+
+    // Reset
+    await page.evaluate(() => localStorage.setItem('kbe-col-width', '2'))
+  })
+
+  // ── Theme Switching ───────────────────────────────────
+
+  test('theme switching changes appearance', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Switch to light
+    await page.getByRole('button', { name: /Light/ }).click()
+    await page.waitForTimeout(1000)
+    const lightBg = await page.evaluate(() => {
+      const el = document.querySelector('[class*=fui-FluentProvider]') || document.documentElement
+      return getComputedStyle(el).backgroundColor
+    })
+
+    // Switch to dark
+    await page.getByRole('button', { name: /Dark/ }).click()
+    await page.waitForTimeout(1000)
+    const darkBg = await page.evaluate(() => {
+      const el = document.querySelector('[class*=fui-FluentProvider]') || document.documentElement
+      return getComputedStyle(el).backgroundColor
+    })
+
+    expect(lightBg).not.toBe(darkBg)
+  })
+
+  // ── Navigation Flow ───────────────────────────────────
+
+  test('Home button navigates to homepage', async ({ page }) => {
+    await page.goto('/#/node/graph-engine', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    await page.getByRole('link', { name: 'Home' }).click()
+    await page.waitForTimeout(2000)
+
+    expect(page.url()).toContain('#/node/home')
+  })
+
+  test('inline links navigate between nodes', async ({ page }) => {
+    await page.goto('/#/node/home', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    // Click a link in the prose
+    const proseLink = page.locator('.kb-prose a[href*="#/node/"]').first()
+    if (await proseLink.count() > 0) {
+      const href = await proseLink.getAttribute('href')
+      await proseLink.click()
+      await page.waitForTimeout(2000)
+      expect(page.url()).toContain('#/node/')
+      expect(page.url()).not.toContain('#/node/home')
+    }
+  })
+
+  // ── Performance ───────────────────────────────────────
+
+  test('page load under 10 seconds', async ({ page }) => {
+    const start = Date.now()
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+    const elapsed = Date.now() - start
+    expect(elapsed).toBeLessThan(10000)
+  })
+
+  test('no console errors on key pages', async ({ page }) => {
+    const errors: string[] = []
+    page.on('console', msg => {
+      if (msg.type() === 'error' && !msg.text().includes('403') && !msg.text().includes('rate')) {
+        errors.push(msg.text())
+      }
+    })
+
+    for (const path of ['/#/node/home', '/#/node/readme', '/#/overview', '/#/node/icon-gallery']) {
+      await page.goto(path, { timeout: 60000 })
+      await page.waitForTimeout(3000)
+    }
+
+    expect(errors).toHaveLength(0)
+  })
+})

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1194,6 +1194,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                     <Button appearance={dock === 'left' ? 'primary' : 'subtle'} size="small" icon={<PanelLeftRegular />} onClick={() => handleDockChange('left')} title="Dock left" />
                     <Button appearance={dock === 'right' ? 'primary' : 'subtle'} size="small" icon={<PanelRightRegular />} onClick={() => handleDockChange('right')} title="Dock right" />
                     <Button appearance="subtle" size="small" icon={<PanelBottomRegular />} onClick={() => handleDockChange('bottom')} title="Dock bottom" />
+                    <Button appearance="subtle" size="small" icon={<PanelTopExpandRegular />} onClick={() => handleDockChange('top')} title="Dock top" />
                   </div>
                 </div>
               </>


### PR DESCRIPTION
Sidebar (left/right) was missing Dock top — now all 4 dock positions reachable from every layout. E2E test cycles all 4 without refresh. 20/20 pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/104" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
