### PR TITLE
fix: Dock top button in sidebar + 20 visual E2E tests

### DIFF
--- a/e2e/visual-validation.spec.ts
+++ b/e2e/visual-validation.spec.ts
@@ -82,9 +82,16 @@ test.describe('Visual Validation', () => {
     const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
     expect(stored).toBe('right')
 
-    // Content should have right padding
-    const screenshot = await page.screenshot()
-    expect(screenshot.byteLength).toBeGreaterThan(0)
+    // Verify sidebar is on the right side
+    const layout = await page.evaluate(() => {
+      const sidebar = document.querySelector('[class*=expandedContent]') as HTMLElement
+      if (!sidebar) return null
+      const rect = sidebar.getBoundingClientRect()
+      return { left: Math.round(rect.left), right: Math.round(rect.right), vpWidth: window.innerWidth }
+    })
+    if (layout) {
+      expect(layout.right).toBeGreaterThan(layout.vpWidth - 50)
+    }
   })
 
   test('dock bottom works without refresh', async ({ page }) => {
@@ -115,6 +122,64 @@ test.describe('Visual Validation', () => {
 
     const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
     expect(stored).toBe('left')
+  })
+
+  test('dock cycles through all 4 positions without refresh', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    const positions = ['left', 'right', 'bottom', 'top'] as const
+    for (const pos of positions) {
+      await page.getByRole('button', { name: `Dock ${pos}` }).click()
+      await page.waitForTimeout(1500)
+
+      const stored = await page.evaluate(() => localStorage.getItem('kbe-hud-dock'))
+      expect(stored).toBe(pos)
+    }
+
+    const hudVisible = await page.evaluate(() => {
+      const buttons = [...document.querySelectorAll('button')]
+      return buttons.some(b => b.title?.includes('Dock'))
+    })
+    expect(hudVisible).toBe(true)
+  })
+
+  test('MAP overlay opens and closes', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    await page.getByRole('button', { name: 'MAP' }).click()
+    await page.waitForTimeout(2000)
+
+    const canvases = await page.locator('canvas').count()
+    expect(canvases).toBeGreaterThanOrEqual(1)
+
+    const dismissBtn = page.getByRole('button', { name: /Dismiss|Close/ })
+    if (await dismissBtn.count() > 0) {
+      await dismissBtn.click()
+    } else {
+      await page.keyboard.press('Escape')
+    }
+    await page.waitForTimeout(1000)
+  })
+
+  test('collapse and expand HUD', async ({ page }) => {
+    await page.goto('/#/node/readme', { timeout: 60000 })
+    await page.waitForTimeout(3000)
+
+    const collapseBtn = page.getByRole('button', { name: 'Collapse' })
+    if (await collapseBtn.count() > 0) {
+      await collapseBtn.click()
+      await page.waitForTimeout(1000)
+
+      const expandBtn = page.getByRole('button', { name: 'Expand' })
+      await expect(expandBtn).toBeVisible({ timeout: 3000 })
+
+      await expandBtn.click()
+      await page.waitForTimeout(1000)
+
+      await expect(page.getByRole('button', { name: 'MAP' })).toBeVisible()
+    }
   })
 
   // ── Content Node Rendering ────────────────────────────

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -1194,6 +1194,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                     <Button appearance={dock === 'left' ? 'primary' : 'subtle'} size="small" icon={<PanelLeftRegular />} onClick={() => handleDockChange('left')} title="Dock left" />
                     <Button appearance={dock === 'right' ? 'primary' : 'subtle'} size="small" icon={<PanelRightRegular />} onClick={() => handleDockChange('right')} title="Dock right" />
                     <Button appearance="subtle" size="small" icon={<PanelBottomRegular />} onClick={() => handleDockChange('bottom')} title="Dock bottom" />
+                    <Button appearance="subtle" size="small" icon={<PanelTopExpandRegular />} onClick={() => handleDockChange('top')} title="Dock top" />
                   </div>
                 </div>
               </>


### PR DESCRIPTION
Sidebar was missing Dock top — now all 4 positions reachable everywhere. 3 new tests (dock cycle, MAP overlay, HUD collapse/expand). 20/20 pass locally.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/105" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
