### PR TITLE
feat: named graph views — All / Code / Docs / Work / External (#44)

### DIFF
--- a/e2e/layer-views.spec.ts
+++ b/e2e/layer-views.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Layer Views', () => {
+test.describe('Graph Views', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/#/node/readme', { timeout: 60000 });
     await page.evaluate(() => localStorage.setItem('kbe-hud-dock', 'left'));
@@ -8,14 +8,14 @@ test.describe('Layer Views', () => {
     await page.waitForTimeout(5000);
   });
 
-  test('Content view filters to authored nodes', async ({ page }) => {
-    await page.getByRole('button', { name: 'Content' }).click();
+  test('Docs view filters to content nodes', async ({ page }) => {
+    await page.getByRole('button', { name: 'Docs' }).click();
     await page.waitForTimeout(3000);
     await expect(page.locator('.kb-prose')).toBeVisible();
   });
 
-  test('Files view shows file tree', async ({ page }) => {
-    await page.getByRole('button', { name: 'Files' }).click();
+  test('Code view shows code-related nodes', async ({ page }) => {
+    await page.getByRole('button', { name: 'Code' }).click();
     await page.waitForTimeout(3000);
     await expect(page.locator('.kb-prose')).toBeVisible();
   });
@@ -26,8 +26,14 @@ test.describe('Layer Views', () => {
     await expect(page.locator('.kb-prose')).toBeVisible();
   });
 
+  test('External view shows Wikipedia nodes + neighbors', async ({ page }) => {
+    await page.getByRole('button', { name: 'External' }).click();
+    await page.waitForTimeout(3000);
+    await expect(page.locator('.kb-prose')).toBeVisible();
+  });
+
   test('All view restores full graph', async ({ page }) => {
-    await page.getByRole('button', { name: 'Content' }).click();
+    await page.getByRole('button', { name: 'Docs' }).click();
     await page.waitForTimeout(1000);
     await page.getByRole('button', { name: 'All' }).click();
     await page.waitForTimeout(3000);

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -32,8 +32,8 @@ import {
   PanelRightRegular,
   PanelTopExpandRegular,
 } from '@fluentui/react-icons';
-import type { KBGraph, KBConfig, KBNode, Theme, EdgeType, NodeLayer } from '../types';
-import { EDGE_TYPE_STYLES, NODE_LAYER_META, filterGraphToLayer, collapseGraphClusters, trimGraphToLimits } from '../types';
+import type { KBGraph, KBConfig, KBNode, Theme, EdgeType } from '../types';
+import { EDGE_TYPE_STYLES, BUILT_IN_VIEWS, filterGraphToView, collapseGraphClusters, trimGraphToLimits } from '../types';
 import type { TrimResult } from '../types';
 import { NodeVisual, FLUENT_ICONS, isFluentIconName } from './NodeVisual';
 import { createGraphNetwork, computeGraphPositions } from '../engine/createGraphNetwork';
@@ -290,10 +290,15 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
   const DETAIL_STEPS = [5, 15, 40, 70, 100];
   const [detailIdx, setDetailIdx] = useState(() => readPersisted('kbe-detail', 2));
   const detailLevel = DETAIL_STEPS[Math.min(detailIdx, DETAIL_STEPS.length - 1)];
-  const [activeLayer, setActiveLayer] = useState<NodeLayer | 'all'>(() => {
+  const [activeView, setActiveView] = useState<string>(() => {
     try {
-      const stored = localStorage.getItem('kbe-layer');
-      if (stored && ['file', 'content', 'work', 'all'].includes(stored)) return stored as NodeLayer | 'all';
+      const stored = localStorage.getItem('kbe-view');
+      if (stored && BUILT_IN_VIEWS.some(v => v.id === stored)) return stored;
+      // Migrate from old layer system
+      const oldLayer = localStorage.getItem('kbe-layer');
+      if (oldLayer === 'file') return 'code';
+      if (oldLayer === 'content') return 'content';
+      if (oldLayer === 'work') return 'work';
     } catch { /* ignore */ }
     return 'all';
   });
@@ -371,9 +376,9 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     document.addEventListener('pointerup', onUp);
   }, [mapSplit]);
 
-  const selectLayer = useCallback((layer: NodeLayer | 'all') => {
-    setActiveLayer(layer);
-    try { localStorage.setItem('kbe-layer', layer); } catch { /* */ }
+  const selectView = useCallback((viewId: string) => {
+    setActiveView(viewId);
+    try { localStorage.setItem('kbe-view', viewId); } catch { /* */ }
   }, []);
 
   const toggleClusterCollapse = useCallback((clusterId: string) => {
@@ -386,12 +391,12 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     });
   }, []);
 
-  // Filter graph: layer view → cluster collapse → trim to limits
+  // Filter graph: view → cluster collapse → trim to limits
   const trimResult = React.useMemo<TrimResult>(() => {
-    let g = activeLayer === 'all' ? graph : filterGraphToLayer(graph, activeLayer);
+    let g = filterGraphToView(graph, activeView);
     if (collapsedClusters.size > 0) g = collapseGraphClusters(g, collapsedClusters);
     return trimGraphToLimits(g, currentNodeId, detailLevel, Infinity);
-  }, [graph, activeLayer, collapsedClusters, currentNodeId, detailLevel]);
+  }, [graph, activeView, collapsedClusters, currentNodeId, detailLevel]);
 
   const filteredGraph = trimResult.graph;
 
@@ -652,14 +657,13 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     } catch { /* node might not exist */ }
   }, [currentNodeId]);
 
-  // Active clusters: use the layer-filtered (but not collapsed) graph for the legend
-  // so collapsed clusters still appear and can be toggled back
+  // Active clusters: use the view-filtered (but not collapsed) graph for the legend
   const activeClusters = React.useMemo(() => {
-    const layerGraph = activeLayer === 'all' ? graph : filterGraphToLayer(graph, activeLayer);
+    const viewGraph = filterGraphToView(graph, activeView);
     const counts = new Map<string, number>();
-    for (const n of layerGraph.nodes) counts.set(n.cluster, (counts.get(n.cluster) ?? 0) + 1);
-    return layerGraph.clusters.filter(c => (counts.get(c.id) ?? 0) >= 2);
-  }, [graph, activeLayer]);
+    for (const n of viewGraph.nodes) counts.set(n.cluster, (counts.get(n.cluster) ?? 0) + 1);
+    return viewGraph.clusters.filter(c => (counts.get(c.id) ?? 0) >= 2);
+  }, [graph, activeView]);
 
   // Active edge types present in the graph
   const activeEdgeTypes = React.useMemo(() => {
@@ -782,30 +786,30 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                 aria-label="Close"
               />
             </div>
-            {/* Layer view selector in overlay */}
+            {/* View selector in overlay */}
             <div style={{
               position: 'absolute', top: 12, left: 12, zIndex: 10,
               display: 'flex', gap: 4,
             }}>
-              {([['all', { label: 'All', color: tokens.colorNeutralForeground1 }], ...Object.entries(NODE_LAYER_META)] as [NodeLayer | 'all', { label: string; color: string }][]).map(([layer, meta]) => {
-                const active = activeLayer === layer;
+              {BUILT_IN_VIEWS.map(view => {
+                const active = activeView === view.id;
                 return (
                   <button
-                    key={layer}
-                    onClick={() => selectLayer(layer)}
+                    key={view.id}
+                    onClick={() => selectView(view.id)}
                     style={{
                       display: 'flex', alignItems: 'center', gap: 5,
                       padding: '4px 12px', fontSize: 12, fontWeight: 500,
-                      border: `1px solid ${active ? meta.color : tokens.colorNeutralStroke2}`,
+                      border: `1px solid ${active ? view.color : tokens.colorNeutralStroke2}`,
                       borderRadius: 14, cursor: 'pointer',
-                      background: active ? (layer === 'all' ? tokens.colorNeutralBackground3 : meta.color + '22') : tokens.colorNeutralBackground1,
-                      color: active ? meta.color : tokens.colorNeutralForeground3,
+                      background: active ? (view.id === 'all' ? tokens.colorNeutralBackground3 : view.color + '22') : tokens.colorNeutralBackground1,
+                      color: active ? view.color : tokens.colorNeutralForeground3,
                       opacity: active ? 1 : 0.6,
                     }}
-                    title={`${meta.label} view`}
+                    title={`${view.name} view`}
                   >
-                    {layer !== 'all' && <span style={{ width: 7, height: 7, borderRadius: '50%', background: meta.color, opacity: active ? 1 : 0.3 }} />}
-                    {meta.label}
+                    {view.id !== 'all' && <span style={{ width: 7, height: 7, borderRadius: '50%', background: view.color, opacity: active ? 1 : 0.3 }} />}
+                    {view.name}
                   </button>
                 );
               })}
@@ -960,30 +964,30 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                     ref={sidebarGraphRef}
                     style={{ width: '100%', height: '100%' }}
                   />
-                  {/* Layer view selector */}
+                  {/* View selector */}
                   <div style={{
                     position: 'absolute', top: 6, left: 8, right: 68, zIndex: 6,
                     display: 'flex', gap: 3, flexWrap: 'wrap',
                   }}>
-                    {([['all', { label: 'All', color: tokens.colorNeutralForeground1 }], ...Object.entries(NODE_LAYER_META)] as [NodeLayer | 'all', { label: string; color: string }][]).map(([layer, meta]) => {
-                      const active = activeLayer === layer;
+                    {BUILT_IN_VIEWS.map(view => {
+                      const active = activeView === view.id;
                       return (
                         <button
-                          key={layer}
-                          onClick={() => selectLayer(layer)}
+                          key={view.id}
+                          onClick={() => selectView(view.id)}
                           style={{
                             display: 'flex', alignItems: 'center', gap: 4,
                             padding: '2px 8px', fontSize: 10, fontWeight: 500,
-                            border: `1px solid ${active ? meta.color : tokens.colorNeutralStroke2}`,
+                            border: `1px solid ${active ? view.color : tokens.colorNeutralStroke2}`,
                             borderRadius: 12, cursor: 'pointer',
-                            background: active ? (layer === 'all' ? tokens.colorNeutralBackground3 : meta.color + '22') : 'transparent',
-                            color: active ? meta.color : tokens.colorNeutralForeground3,
+                            background: active ? (view.id === 'all' ? tokens.colorNeutralBackground3 : view.color + '22') : 'transparent',
+                            color: active ? view.color : tokens.colorNeutralForeground3,
                             opacity: active ? 1 : 0.5,
                           }}
-                          title={`${meta.label} view`}
+                          title={`${view.name} view`}
                         >
-                          {layer !== 'all' && <span style={{ width: 6, height: 6, borderRadius: '50%', background: meta.color, opacity: active ? 1 : 0.3 }} />}
-                          {meta.label}
+                          {view.id !== 'all' && <span style={{ width: 6, height: 6, borderRadius: '50%', background: view.color, opacity: active ? 1 : 0.3 }} />}
+                          {view.name}
                         </button>
                       );
                     })}
@@ -993,6 +997,7 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                     <Caption2 style={{
                       position: 'absolute', top: 28, left: 10, zIndex: 7,
                       color: tokens.colorNeutralForeground3, opacity: 0.7, fontSize: 9,
+                      pointerEvents: 'none',
                     }}>
                       {filteredGraph.nodes.length}/{trimResult.totalNodes} nodes
                     </Caption2>

--- a/src/engine/providers/work-provider.ts
+++ b/src/engine/providers/work-provider.ts
@@ -85,7 +85,7 @@ export class WorkProvider implements GraphProvider {
         rawContent: commitContent,
         emoji: 'History',
         connections: [],
-        source: { type: 'file', path: '.git/log' },
+        source: { type: 'commit', sha: 'summary' },
         provider: 'work',
       });
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -228,6 +228,92 @@ function filterByPredicate(graph: KBGraph, predicate: (n: KBNode) => boolean): K
   return { nodes, edges, clusters: graph.clusters, related };
 }
 
+// ── Graph Views ────────────────────────────────────────────
+
+/** A named view projection over the graph */
+export interface GraphView {
+  id: string
+  name: string
+  icon: string
+  color: string
+  /** Resolve this view — custom logic, not just a filter */
+  resolve: (graph: KBGraph) => KBGraph
+}
+
+/** Built-in views — each with a custom resolver */
+export const BUILT_IN_VIEWS: GraphView[] = [
+  {
+    id: 'all',
+    name: 'All',
+    icon: '',
+    color: '#ffffff',
+    resolve: (graph) => graph,
+  },
+  {
+    id: 'code',
+    name: 'Code',
+    icon: 'Code',
+    color: '#9A8A78',
+    resolve: (graph) => filterByPredicate(graph, n => {
+      const t = n.source.type
+      if (t === 'file') return true
+      // Include authored nodes in code-related clusters
+      if ((t === 'authored' || t === 'derived') &&
+        ['engine', 'data', 'infra'].includes(n.cluster)) return true
+      return false
+    }),
+  },
+  {
+    id: 'content',
+    name: 'Docs',
+    icon: 'Document',
+    color: '#58a6ff',
+    resolve: (graph) => filterGraphToLayer(graph, 'content'),
+  },
+  {
+    id: 'work',
+    name: 'Work',
+    icon: 'Wrench',
+    color: '#d29922',
+    resolve: (graph) => filterByPredicate(graph, n => {
+      const t = n.source.type
+      return t === 'issue' || t === 'pull_request' || t === 'commit'
+    }),
+  },
+  {
+    id: 'external',
+    name: 'External',
+    icon: 'Globe',
+    color: '#79C0FF',
+    resolve: (graph) => {
+      // External nodes + their 1-hop internal neighbors
+      const externalIds = new Set(
+        graph.nodes.filter(n => n.source.type === 'external').map(n => n.id)
+      )
+      const neighborIds = new Set<string>()
+      for (const e of graph.edges) {
+        if (externalIds.has(e.from)) neighborIds.add(e.to)
+        if (externalIds.has(e.to)) neighborIds.add(e.from)
+      }
+      const visibleIds = new Set([...externalIds, ...neighborIds])
+      return filterByPredicate(graph, n => visibleIds.has(n.id))
+    },
+  },
+]
+
+/** Get a view by ID (built-in or custom) */
+export function getView(id: string): GraphView | undefined {
+  return BUILT_IN_VIEWS.find(v => v.id === id)
+}
+
+/** Apply a view to a graph */
+export function filterGraphToView(graph: KBGraph, viewId: string): KBGraph {
+  if (viewId === 'all') return graph
+  const view = getView(viewId)
+  if (!view) return graph
+  return view.resolve(graph)
+}
+
 /**
  * Collapse specified clusters into single summary nodes.
  * Each collapsed cluster's nodes are replaced with one summary node;


### PR DESCRIPTION
Closes #44

Replaces the layer toggle system with 5 named graph views, each with a custom resolver:

- **All** — full graph
- **Code** — files + code-related authored nodes
- **Docs** — content layer with identity remapping
- **Work** — issues, PRs, commits
- **External** — Wikipedia/external nodes + their 1-hop neighbors

Views are resolvers, not just filters — the Docs view preserves identity remapping, External includes neighborhood context.

Also fixes: commit node source type (was 'file', now 'commit'), trim indicator pointer-events.

176 unit + 25 E2E tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
