### PR TITLE
feat: rich GitHub nodes with metadata + smart link remapping

### DIFF
--- a/src/engine/__tests__/parser.test.ts
+++ b/src/engine/__tests__/parser.test.ts
@@ -107,7 +107,8 @@ describe('issueToNode', () => {
 
   it('handles null body', () => {
     const node = issueToNode({ ...mockIssue, body: null });
-    expect(node.rawContent).toBe('');
+    expect(node.rawContent).toContain('OPEN');
+    expect(node.rawContent).toContain('View on GitHub');
     expect(node.connections).toEqual([]);
   });
 

--- a/src/engine/parser.ts
+++ b/src/engine/parser.ts
@@ -168,22 +168,63 @@ export function issueToNode(issue: GHIssue): KBNode {
   const labels = issue.labels.map(l => l.name);
   const cluster = labels[0]?.toLowerCase() ?? 'uncategorized';
   const body = issue.body ?? '';
-  const html = marked.parse(body, { async: false }) as string;
+
+  // Remap GitHub issue/PR links to graph node links
+  const remappedBody = body
+    .replace(/https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/g, (_m, num) => `issue-${num}`)
+    .replace(/https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/g, (_m, num) => `pr-${num}`)
+
   const refs = extractIssueRefs(body);
+  // Also extract PR references from body
+  const prRefs = [...body.matchAll(/(?:^|\s)#(\d+)/g)].map(m => Number(m[1]));
+
+  // Build rich metadata header
+  const stateEmoji = issue.state === 'open' ? '🟢' : '🟣';
+  const labelBadges = labels.map(l => `\`${l}\``).join(' ');
+  const assigneeList = issue.assignees?.length
+    ? issue.assignees.map(a => `@${a.login}`).join(', ')
+    : '';
+  const created = new Date(issue.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  const updated = new Date(issue.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+  const metaLines = [
+    `${stateEmoji} **${issue.state.toUpperCase()}** · #${issue.number}`,
+    labelBadges ? `Labels: ${labelBadges}` : '',
+    assigneeList ? `Assignees: ${assigneeList}` : '',
+    `Created: ${created} · Updated: ${updated}`,
+    `[View on GitHub ↗](${issue.html_url})`,
+  ].filter(Boolean).join('\n\n');
+
+  const fullContent = `${metaLines}\n\n---\n\n${remappedBody}`;
+  const html = marked.parse(fullContent, { async: false }) as string;
+
+  // Build connections — both issue refs and PR refs
+  const connections: Connection[] = [];
+  const seen = new Set<string>();
+  for (const n of refs) {
+    const to = `issue-${n}`;
+    if (!seen.has(to)) {
+      connections.push({ to, type: 'cross_references', description: `References #${n}`, source: 'inline' });
+      seen.add(to);
+    }
+  }
+  for (const n of prRefs) {
+    const prTo = `pr-${n}`;
+    if (!seen.has(prTo) && !seen.has(`issue-${n}`)) {
+      // Could be a PR reference — add both possibilities
+      connections.push({ to: `issue-${n}`, type: 'cross_references', description: `References #${n}`, source: 'inline' });
+      seen.add(`issue-${n}`);
+    }
+  }
 
   const node: KBNode = {
     id: `issue-${issue.number}`,
     title: issue.title,
     cluster,
     content: html,
-    rawContent: body,
+    rawContent: fullContent,
     emoji: issueIcon(labels),
-    connections: refs.map(n => ({
-      to: `issue-${n}`,
-      type: 'cross_references' as const,
-      description: `References #${n}`,
-      source: 'inline' as const,
-    })),
+    connections,
     source: { type: 'issue', number: issue.number, state: issue.state, labels },
   };
   node.identity = assignIdentity(node);

--- a/src/engine/providers/work-provider.ts
+++ b/src/engine/providers/work-provider.ts
@@ -49,19 +49,49 @@ export class WorkProvider implements GraphProvider {
     // Pull requests
     for (const pr of this.pullRequests) {
       const body = pr.body ?? '';
-      const html = marked.parse(body, { async: false }) as string;
+
+      // Remap GitHub links to graph node links
+      const remappedBody = body
+        .replace(/https?:\/\/github\.com\/[^/]+\/[^/]+\/issues\/(\d+)/g, (_m: string, num: string) => `issue-${num}`)
+        .replace(/https?:\/\/github\.com\/[^/]+\/[^/]+\/pull\/(\d+)/g, (_m: string, num: string) => `pr-${num}`)
+
       const refs = extractIssueRefs(body);
+
+      // Rich metadata header
+      const stateEmoji = pr.state === 'open' ? '🟢' : pr.state === 'merged' ? '🟣' : '🔴';
+      const labelBadges = pr.labels?.map(l => `\`${l.name}\``).join(' ') ?? '';
+      const created = new Date(pr.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+      const updated = new Date(pr.updated_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+      const metaLines = [
+        `${stateEmoji} **${(pr.state || 'closed').toUpperCase()}** · PR #${pr.number}`,
+        labelBadges ? `Labels: ${labelBadges}` : '',
+        `Created: ${created} · Updated: ${updated}`,
+        `[View on GitHub ↗](${pr.html_url})`,
+      ].filter(Boolean).join('\n\n');
+
+      const fullContent = `${metaLines}\n\n---\n\n${remappedBody}`;
+      const html = marked.parse(fullContent, { async: false }) as string;
+
+      // Build connections
+      const connections: Array<{ to: string; description: string }> = [];
+      const seen = new Set<string>();
+      for (const n of refs) {
+        const to = `issue-${n}`;
+        if (!seen.has(to)) {
+          connections.push({ to, description: `References #${n}` });
+          seen.add(to);
+        }
+      }
+
       const prNode: KBNode = {
         id: `pr-${pr.number}`,
         title: pr.title,
         cluster: 'pull-request',
         content: html,
-        rawContent: body,
+        rawContent: fullContent,
         emoji: 'BranchFork',
-        connections: refs.map(n => ({
-          to: `issue-${n}`,
-          description: `References #${n}`,
-        })),
+        connections,
         source: { type: 'pull_request', number: pr.number, state: pr.state },
         provider: 'work',
       };
@@ -73,9 +103,29 @@ export class WorkProvider implements GraphProvider {
     if (this.commits.length > 0) {
       const commitList = this.commits
         .slice(0, 30)
-        .map(c => `- \`${c.sha.substring(0, 7)}\` ${c.commit.message}`)
+        .map(c => {
+          const msg = c.commit.message.split('\n')[0];
+          const date = new Date(c.commit.author.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+          const refs = extractIssueRefs(c.commit.message);
+          const refLinks = refs.map(n => `[#${n}](issue-${n})`).join(' ');
+          return `- \`${c.sha.substring(0, 7)}\` ${msg}${refLinks ? ' — ' + refLinks : ''} *(${date})*`;
+        })
         .join('\n');
-      const commitContent = `## Recent Commits\n\n${this.commits.length} commits\n\n${commitList}`;
+
+      // Extract issue refs from all commit messages for connections
+      const commitConnections: Array<{ to: string; description: string }> = [];
+      const seenRefs = new Set<string>();
+      for (const c of this.commits) {
+        for (const n of extractIssueRefs(c.commit.message)) {
+          const to = `issue-${n}`;
+          if (!seenRefs.has(to)) {
+            commitConnections.push({ to, description: `Commit references #${n}` });
+            seenRefs.add(to);
+          }
+        }
+      }
+
+      const commitContent = `## Recent Commits\n\n${this.commits.length} commits · ${this.commits[0]?.commit.author.name ?? 'unknown'}\n\n${commitList}`;
       const commitHtml = marked.parse(commitContent, { async: false }) as string;
       nodes.push({
         id: 'commits',
@@ -84,7 +134,7 @@ export class WorkProvider implements GraphProvider {
         content: commitHtml,
         rawContent: commitContent,
         emoji: 'History',
-        connections: [],
+        connections: commitConnections,
         source: { type: 'commit', sha: 'summary' },
         provider: 'work',
       });

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -330,7 +330,22 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
       }
     );
 
-    // 2. Convert markdown-generated <a href="node-id"> to hash-based graph navigation
+    // 2. Remap GitHub issue/PR URLs to graph nodes (skip "View on GitHub" external links)
+    result = result.replace(
+      /<a href="(https?:\/\/github\.com\/[^"]*?\/(issues|pull)\/(\d+))">([^<]*)<\/a>/g,
+      (match, url: string, type: string, num: string, text: string) => {
+        if (text.includes('↗') || text.includes('View on GitHub')) {
+          return `<a href="${url}" target="_blank" rel="noopener">${text}</a>`;
+        }
+        const nodeId = type === 'pull' ? `pr-${num}` : `issue-${num}`;
+        if (nodeIds.has(nodeId)) {
+          return `<a href="#/node/${encodeURIComponent(nodeId)}">${text}</a>`;
+        }
+        return match;
+      }
+    );
+
+    // 3. Convert markdown-generated <a href="node-id"> to hash-based graph navigation
     result = result.replace(
       /<a href="([^"#/][^"]*)">/g,
       (_match, target: string) => {
@@ -339,6 +354,12 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
         }
         return `<a href="${target}">`;
       }
+    );
+
+    // 4. Make external links open in new tab
+    result = result.replace(
+      /<a href="(https?:\/\/[^"]+)">/g,
+      '<a href="$1" target="_blank" rel="noopener">'
     );
 
     return result;


### PR DESCRIPTION
Issues and PRs now show state badges, labels, dates, assignees, and a 'View on GitHub ↗' external link. GitHub URLs in body text remap to graph nodes (navigate in-app first). External links open in new tab. Commits show dates and issue refs as inline graph links. 176 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/110" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
