### PR TITLE
feat: repository + branch nodes in the knowledge graph

### DIFF
--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -230,7 +230,7 @@ export function fetchLocalPullRequests(cwd = hostRoot) {
   }
   try {
     const json = execSync(
-      'gh pr list --json number,title,body,state,labels,url,createdAt,updatedAt --state all --limit 200',
+      'gh pr list --json number,title,body,state,labels,url,createdAt,updatedAt,headRefName --state all --limit 200',
       { cwd, encoding: 'utf-8', timeout: 30000 },
     );
     const prs = JSON.parse(json);
@@ -246,6 +246,7 @@ export function fetchLocalPullRequests(cwd = hostRoot) {
       html_url: pr.url ?? '',
       created_at: pr.createdAt ?? '',
       updated_at: pr.updatedAt ?? '',
+      head_branch: pr.headRefName ?? '',
     }));
   } catch (err) {
     console.warn('[generate-manifest] Failed to fetch PRs:', err.message);
@@ -278,6 +279,67 @@ export function fetchLocalCommits(cwd = hostRoot) {
   } catch (err) {
     console.warn('[generate-manifest] Failed to fetch commits:', err.message);
     return [];
+  }
+}
+
+/**
+ * Fetch branches via gh CLI.
+ * @returns {Array}
+ */
+export function fetchLocalBranches(cwd = hostRoot) {
+  if (!isGhAvailable()) return [];
+  try {
+    const json = execSync(
+      'gh api repos/{owner}/{repo}/branches --paginate --jq "[.[] | {name, protected: .protected}]"',
+      { cwd, encoding: 'utf-8', timeout: 30000 },
+    );
+    return JSON.parse(json);
+  } catch {
+    // Fallback to git branch
+    try {
+      const raw = execSync('git branch -a --format="%(refname:short)|||%(upstream:track)"', { cwd, encoding: 'utf-8', timeout: 10000 });
+      return raw.trim().split('\n').filter(Boolean).map(line => {
+        const [name] = line.split('|||');
+        return { name: name.replace('origin/', ''), protected: name === 'main' || name === 'master' };
+      }).filter((b, i, arr) => arr.findIndex(x => x.name === b.name) === i);
+    } catch {
+      return [];
+    }
+  }
+}
+
+/**
+ * Fetch repository metadata via gh CLI.
+ * @returns {Object|null}
+ */
+export function fetchRepoMetadata(cwd = hostRoot) {
+  if (!isGhAvailable()) return null;
+  try {
+    const json = execSync(
+      'gh repo view --json name,description,url,homepageUrl,defaultBranchRef,stargazerCount,forkCount,isPrivate,repositoryTopics,primaryLanguage,languages,owner',
+      { cwd, encoding: 'utf-8', timeout: 15000 },
+    );
+    const data = JSON.parse(json);
+    return {
+      name: data.name ?? '',
+      description: data.description ?? '',
+      html_url: data.url ?? '',
+      homepage: data.homepageUrl ?? '',
+      default_branch: data.defaultBranchRef?.name ?? 'main',
+      stargazers_count: data.stargazerCount ?? 0,
+      forks_count: data.forkCount ?? 0,
+      private: data.isPrivate ?? false,
+      topics: (data.repositoryTopics ?? []).map(t => t.name ?? t),
+      primary_language: data.primaryLanguage?.name ?? '',
+      languages: (data.languages ?? []).map(l => ({ name: l.node?.name ?? l.name ?? l, size: l.size ?? 0 })),
+      owner: {
+        login: data.owner?.login ?? '',
+        avatar_url: data.owner?.avatarUrl ?? '',
+      },
+    };
+  } catch (err) {
+    console.warn('[generate-manifest] Failed to fetch repo metadata:', err.message);
+    return null;
   }
 }
 
@@ -436,6 +498,8 @@ export function generateManifest(root = hostRoot) {
     issues: fetchLocalIssues(root),
     pullRequests: fetchLocalPullRequests(root),
     commits: fetchLocalCommits(root),
+    branches: fetchLocalBranches(root),
+    repoMetadata: fetchRepoMetadata(root),
     nodemapRaw,
     nodemapFiles,
     nodemapDirs,
@@ -450,6 +514,8 @@ export function generateManifest(root = hostRoot) {
   console.log(`[generate-manifest] Issues: ${manifest.issues.length}`);
   console.log(`[generate-manifest] PRs: ${manifest.pullRequests.length}`);
   console.log(`[generate-manifest] Commits: ${manifest.commits.length}`);
+  console.log(`[generate-manifest] Branches: ${manifest.branches.length}`);
+  console.log(`[generate-manifest] Repo: ${manifest.repoMetadata?.name ?? 'not available'}`);
   console.log(`[generate-manifest] Nodemap: ${nodemapRaw ? `${Object.keys(nodemapFiles).length} files, ${Object.keys(nodemapDirs).length} dirs` : 'not found'}`);
 
   return manifest;

--- a/src/engine/local-loader.ts
+++ b/src/engine/local-loader.ts
@@ -43,12 +43,27 @@ interface RepoManifest {
     html_url: string;
     created_at: string;
     updated_at: string;
+    head_branch?: string;
   }>;
   commits: Array<{
     sha: string;
     commit: { message: string; author: { name: string; date: string } };
     html_url: string;
   }>;
+  branches?: Array<{ name: string; protected: boolean }>;
+  repoMetadata?: {
+    name: string;
+    description: string;
+    html_url: string;
+    default_branch: string;
+    stargazers_count: number;
+    forks_count: number;
+    private: boolean;
+    topics: string[];
+    primary_language: string;
+    languages: Array<{ name: string; size: number }>;
+    owner: { login: string; avatar_url: string };
+  } | null;
   nodemapRaw?: string | null;
   nodemapFiles?: Record<string, string>;
   nodemapDirs?: Record<string, Array<{ path: string; type: 'blob' | 'tree'; size?: number }>>;
@@ -331,7 +346,7 @@ async function loadLocalKnowledgeBaseV2(): Promise<{
   );
 
   registry.register(
-    new WorkProvider(manifest.issues, manifest.pullRequests, manifest.commits),
+    new WorkProvider(manifest.issues, manifest.pullRequests, manifest.commits, manifest.branches ?? [], manifest.repoMetadata ?? null),
   );
 
   // ── Register external providers from config ────────────

--- a/src/engine/providers/work-provider.ts
+++ b/src/engine/providers/work-provider.ts
@@ -27,12 +27,27 @@ export class WorkProvider implements GraphProvider {
       html_url: string;
       created_at: string;
       updated_at: string;
+      head_branch?: string;
     }>,
     private commits: Array<{
       sha: string;
       commit: { message: string; author: { name: string; date: string } };
       html_url: string;
     }>,
+    private branches: Array<{ name: string; protected: boolean }> = [],
+    private repoMetadata: {
+      name: string;
+      description: string;
+      html_url: string;
+      default_branch: string;
+      stargazers_count: number;
+      forks_count: number;
+      private: boolean;
+      topics: string[];
+      primary_language: string;
+      languages: Array<{ name: string; size: number }>;
+      owner: { login: string; avatar_url: string };
+    } | null = null,
   ) {}
 
   async resolve(_config: KBConfig, _existingNodes: KBNode[]): Promise<ProviderResult> {
@@ -82,6 +97,11 @@ export class WorkProvider implements GraphProvider {
           connections.push({ to, description: `References #${n}` });
           seen.add(to);
         }
+      }
+
+      // PR → branch connection
+      if (pr.head_branch) {
+        connections.push({ to: `branch-${pr.head_branch}`, description: `Branch: ${pr.head_branch}` });
       }
 
       const prNode: KBNode = {
@@ -136,6 +156,72 @@ export class WorkProvider implements GraphProvider {
         emoji: 'History',
         connections: commitConnections,
         source: { type: 'commit', sha: 'summary' },
+        provider: 'work',
+      });
+    }
+
+    // ── Repository node ──────────────────────────────────
+    if (this.repoMetadata) {
+      const meta = this.repoMetadata;
+      const langList = meta.languages
+        .sort((a, b) => b.size - a.size)
+        .slice(0, 10)
+        .map(l => `- **${l.name}** (${Math.round(l.size / 1024)}KB)`)
+        .join('\n');
+      const topicBadges = meta.topics.map(t => `\`${t}\``).join(' ');
+
+      const repoContent = [
+        `${meta.private ? '🔒 Private' : '🌐 Public'} · ⭐ ${meta.stargazers_count} · 🍴 ${meta.forks_count}`,
+        meta.description ? `\n${meta.description}` : '',
+        topicBadges ? `\n\nTopics: ${topicBadges}` : '',
+        `\n\n## Languages\n\n${langList || 'No language data'}`,
+        `\n\nDefault branch: \`${meta.default_branch}\``,
+        `\n\n[View on GitHub ↗](${meta.html_url})`,
+      ].join('');
+
+      const repoHtml = marked.parse(repoContent, { async: false }) as string;
+      const repoConns: Array<{ to: string; description: string }> = [
+        { to: 'readme', description: 'README' },
+        { to: `branch-${meta.default_branch}`, description: `Default branch` },
+      ];
+
+      nodes.push({
+        id: 'repo-meta',
+        title: meta.name,
+        cluster: 'infra',
+        content: repoHtml,
+        rawContent: repoContent,
+        emoji: 'Organization',
+        display: 'repository' as any,
+        image: meta.owner.avatar_url || undefined,
+        connections: repoConns,
+        source: { type: 'repository', owner: meta.owner.login, repo: meta.name },
+        provider: 'work',
+      });
+    }
+
+    // ── Branch nodes ─────────────────────────────────────
+    for (const branch of this.branches) {
+      const protectedBadge = branch.protected ? '🛡️ Protected' : '';
+      const isDefault = this.repoMetadata?.default_branch === branch.name;
+      const branchContent = [
+        `${isDefault ? '**Default branch**' : 'Branch'} · \`${branch.name}\``,
+        protectedBadge ? ` · ${protectedBadge}` : '',
+      ].join('');
+
+      const branchHtml = marked.parse(branchContent, { async: false }) as string;
+      const branchConns: Array<{ to: string; description: string }> = [];
+      if (isDefault) branchConns.push({ to: 'repo-meta', description: 'Repository' });
+
+      nodes.push({
+        id: `branch-${branch.name}`,
+        title: branch.name,
+        cluster: isDefault ? 'infra' : 'pull-request',
+        content: branchHtml,
+        rawContent: branchContent,
+        emoji: branch.protected ? 'ShieldCheckmark' : 'Branch',
+        connections: branchConns,
+        source: { type: 'branch', name: branch.name, protected: branch.protected },
         provider: 'work',
       });
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 /** Core data types for the kbexplorer knowledge graph. */
 
-export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage' | 'gallery' | 'icon-detail';
+export type DisplayMode = 'prose' | 'code' | 'file-list' | 'tree' | 'table' | 'diagram' | 'homepage' | 'gallery' | 'icon-detail' | 'repository';
 
 /** A single entry in nodemap.yaml */
 export interface NodeMapEntry {
@@ -118,7 +118,7 @@ export function getNodeLayer(node: KBNode): NodeLayer {
   const t = node.source.type;
   if (t === 'authored' || t === 'readme' || t === 'derived') return 'content';
   if (t === 'section') return 'content';
-  if (t === 'issue' || t === 'pull_request' || t === 'commit') return 'work';
+  if (t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository') return 'work';
   return 'file';
 }
 
@@ -277,7 +277,7 @@ export const BUILT_IN_VIEWS: GraphView[] = [
     color: '#d29922',
     resolve: (graph) => filterByPredicate(graph, n => {
       const t = n.source.type
-      return t === 'issue' || t === 'pull_request' || t === 'commit'
+      return t === 'issue' || t === 'pull_request' || t === 'commit' || t === 'branch' || t === 'workflow' || t === 'repository'
     }),
   },
   {
@@ -579,7 +579,10 @@ export type NodeSource =
   | { type: 'readme' }
   | { type: 'section'; parentSource: NodeSource }
   | { type: 'derived'; generator: string }
-  | { type: 'external'; provider: string };
+  | { type: 'external'; provider: string }
+  | { type: 'branch'; name: string; protected: boolean }
+  | { type: 'workflow'; path: string }
+  | { type: 'repository'; owner: string; repo: string };
 
 /** Configuration for an external provider plugin */
 export interface ExternalProviderConfig {

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -350,6 +350,18 @@ function SourceBadge({ node, config }: { node: KBNode; config: KBConfig }) {
       label = `External · ${s.provider}`
       color = '#79C0FF'
       break
+    case 'branch':
+      label = `Branch · ${s.name}${s.protected ? ' 🛡️' : ''}`
+      color = '#a78bfa'
+      break
+    case 'workflow':
+      label = `Workflow · ${s.path.replace('.github/workflows/', '')}`
+      color = '#e3b341'
+      break
+    case 'repository':
+      label = `Repository · ${s.owner}/${s.repo}`
+      color = '#56d364'
+      break
     case 'section':
       label = 'Section'
       color = '#8b949e'


### PR DESCRIPTION
Repository node shows languages, topics, stars, description. Branch nodes link from PRs via head_branch. 14 branches + repo metadata fetched. Source badges for branch/repo/workflow. 176 tests pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/117" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
