### PR TITLE
fix: Cards next to Home + wider resize handle + clickable collapsed bar

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -905,12 +905,17 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
 
       <div className={styles.hud} style={hudContainerStyle}>
         {collapsed ? (
-          <div className={styles.collapsedBar}>
+          <div
+            className={styles.collapsedBar}
+            onClick={isVertical ? () => handleCollapse(false) : undefined}
+            style={isVertical ? { cursor: 'pointer' } : undefined}
+            title={isVertical ? 'Click to expand' : undefined}
+          >
             <Button
               size="small"
               appearance="subtle"
               icon={expandIcon}
-              onClick={() => handleCollapse(false)}
+              onClick={(e) => { e.stopPropagation(); handleCollapse(false); }}
               title="Expand"
             />
             {!isVertical && (
@@ -950,13 +955,32 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                   style={{
                     position: 'absolute',
                     top: 0,
-                    [dock === 'left' ? 'right' : 'left']: 0,
-                    width: 5,
+                    [dock === 'left' ? 'right' : 'left']: -4,
+                    width: 12,
                     height: '100%',
                     cursor: 'col-resize',
                     zIndex: 10,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
                   }}
-                />
+                >
+                  <div style={{
+                    width: 4,
+                    height: 32,
+                    borderRadius: 2,
+                    background: tokens.colorNeutralStroke2,
+                    opacity: 0.6,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                    gap: 2,
+                  }}>
+                    <div style={{ width: 4, height: 1, background: tokens.colorNeutralForeground3, borderRadius: 1 }} />
+                    <div style={{ width: 4, height: 1, background: tokens.colorNeutralForeground3, borderRadius: 1 }} />
+                    <div style={{ width: 4, height: 1, background: tokens.colorNeutralForeground3, borderRadius: 1 }} />
+                  </div>
+                </div>
 
                 {/* Live constellation graph */}
                 <div style={{ flex: `0 0 ${mapSplit}%`, minHeight: '20%', position: 'relative', overflow: 'hidden', paddingTop: 36 }}>

--- a/src/views/OverviewView.tsx
+++ b/src/views/OverviewView.tsx
@@ -8,9 +8,13 @@ import {
   CardHeader,
   CounterBadge,
   Badge,
+  Button,
   makeStyles,
   tokens,
 } from '@fluentui/react-components';
+import {
+  ArrowLeftRegular,
+} from '@fluentui/react-icons';
 import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
 
@@ -119,6 +123,11 @@ export function OverviewView({ graph, config }: OverviewViewProps) {
 
   return (
     <div className={classes.root}>
+      <div style={{ marginBottom: tokens.spacingVerticalM }}>
+        <Button appearance="subtle" icon={<ArrowLeftRegular />} as="a" href="#/">
+          Home
+        </Button>
+      </div>
       <Title1 as="h1" className={classes.title}>{config.title}</Title1>
       {config.subtitle && (
         <Body1 className={classes.subtitle}>{config.subtitle}</Body1>

--- a/src/views/ReadingView.tsx
+++ b/src/views/ReadingView.tsx
@@ -10,6 +10,7 @@ import {
 } from '@fluentui/react-components';
 import {
   ArrowLeftRegular,
+  GridRegular,
 } from '@fluentui/react-icons';
 import type { KBGraph, KBConfig, KBNode, Cluster } from '../types';
 import { NodeVisual } from '../components/NodeVisual';
@@ -466,11 +467,14 @@ export function ReadingView({ graph, config, nodeId }: ReadingViewProps) {
         <NodeVisual node={node} mode={mode} surface="hero" source={source} />
       )}
 
-      {/* Back link — hide on homepage (it IS home) */}
+      {/* Navigation — hide on homepage (it IS home) */}
       {!isHomepage && (
-        <div className={styles.backLink}>
+        <div className={styles.backLink} style={{ display: 'flex', gap: 4 }}>
           <Button appearance="subtle" icon={<ArrowLeftRegular />} as="a" href="#/">
             Home
+          </Button>
+          <Button appearance="subtle" icon={<GridRegular />} as="a" href="#/overview">
+            Cards
           </Button>
         </div>
       )}


### PR DESCRIPTION
- Cards button next to Home at top of reading view
- Home button on overview page (no more stranded)
- Sidebar resize handle 12px wide with 3-line grip indicator
- Collapsed sidebar: entire bar clickable to expand

Verified with Playwright.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
