### PR TITLE
fix: thicker sidebar border + interface screenshot on homepage

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -42,6 +42,8 @@ Knowledge lives in many places. Source code in one repository, issues in another
 
 ## The interface
 
+![kbexplorer with sidebar graph, reading view, and cluster legend](screenshots/02-sidebar-graph-dark.png)
+
 See kbexplorer in action: the [constellation graph](ui-constellation) with its multi-tier edge importance, [three themes](ui-themes) (dark, light, sepia), [dock positions](ui-dock-layout) that rearrange the entire layout, different [node types](ui-node-types) from GitHub issues to Wikipedia articles, and the [card overview](ui-card-overview) for scanning the full knowledge base at a glance.
 
 ## How it works

--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -698,19 +698,19 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
     ...(dock === 'bottom' ? {
       bottom: 0, left: 0, right: 0,
       height: collapsed ? 40 : 148,
-      borderTop: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderTop: `2px solid ${tokens.colorNeutralStroke1}`,
     } : dock === 'top' ? {
       top: 0, left: 0, right: 0,
       height: collapsed ? 40 : 148,
-      borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderBottom: `2px solid ${tokens.colorNeutralStroke1}`,
     } : dock === 'left' ? {
       top: 0, left: 0, bottom: 0,
       width: collapsed ? 40 : `${sidebarWidth}vw`,
-      borderRight: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderRight: `2px solid ${tokens.colorNeutralStroke1}`,
     } : {
       top: 0, right: 0, bottom: 0,
       width: collapsed ? 40 : `${sidebarWidth}vw`,
-      borderLeft: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderLeft: `2px solid ${tokens.colorNeutralStroke1}`,
     }),
   };
 


### PR DESCRIPTION
HUD border 1px→2px with stronger stroke token. Homepage shows a screenshot under 'The interface' heading.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
