### PR TITLE
fix: visible resize grip on sidebar border

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -950,19 +950,33 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
             {/* Minimap — always mounted, one canvas element */}
             {isVertical ? (
               <>
-                {/* Sidebar resize handle — sits on the border */}
+                {/* Sidebar resize handle — visible grip on the border */}
                 <div
                   onPointerDown={handleResizeStart}
+                  className="kbe-resize-handle"
                   style={{
                     position: 'absolute',
                     top: 0,
-                    [dock === 'left' ? 'right' : 'left']: -4,
-                    width: 4,
+                    [dock === 'left' ? 'right' : 'left']: -5,
+                    width: 10,
                     height: '100%',
                     cursor: 'col-resize',
                     zIndex: 10,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
                   }}
-                />
+                >
+                  {/* Two vertical lines — classic resize affordance */}
+                  <div style={{
+                    display: 'flex',
+                    gap: 3,
+                    height: 44,
+                  }}>
+                    <div style={{ width: 2, height: '100%', borderRadius: 1, background: '#aaa' }} />
+                    <div style={{ width: 2, height: '100%', borderRadius: 1, background: '#aaa' }} />
+                  </div>
+                </div>
 
                 {/* Live constellation graph */}
                 <div style={{ flex: `0 0 ${mapSplit}%`, minHeight: '20%', position: 'relative', overflow: 'hidden', paddingTop: 36 }}>

--- a/src/styles/hud.css
+++ b/src/styles/hud.css
@@ -1,5 +1,13 @@
 /* hud.css — responsive overrides only (layout handled by makeStyles) */
 
+/* Resize handle — pill grip brightens on hover */
+.kbe-resize-handle > div {
+  transition: opacity 0.15s;
+}
+.kbe-resize-handle:hover > div {
+  opacity: 0.8 !important;
+}
+
 /* Tablet: reduce HUD height, hide minimap panel */
 @media (min-width: 769px) and (max-width: 1024px) {
   /* Minimap panel hides on tablet via parent container query — 


### PR DESCRIPTION
Two vertical bars (#aaa, 44px tall) on the sidebar border edge. Brightens on hover. 10px hit area for easy targeting.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/123" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
