### PR TITLE
fix: resize grip inside sidebar

### DIFF
--- a/src/components/HUD.tsx
+++ b/src/components/HUD.tsx
@@ -950,15 +950,15 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
             {/* Minimap — always mounted, one canvas element */}
             {isVertical ? (
               <>
-                {/* Sidebar resize handle — visible grip on the border */}
+                {/* Sidebar resize handle — inside the sidebar edge */}
                 <div
                   onPointerDown={handleResizeStart}
                   className="kbe-resize-handle"
                   style={{
                     position: 'absolute',
                     top: 0,
-                    [dock === 'left' ? 'right' : 'left']: -5,
-                    width: 10,
+                    [dock === 'left' ? 'right' : 'left']: 0,
+                    width: 12,
                     height: '100%',
                     cursor: 'col-resize',
                     zIndex: 10,
@@ -967,7 +967,6 @@ export function HUD({ graph, config, currentNodeId, theme, onThemeChange, onColl
                     justifyContent: 'center',
                   }}
                 >
-                  {/* Two vertical lines — classic resize affordance */}
                   <div style={{
                     display: 'flex',
                     gap: 3,


### PR DESCRIPTION
Grip bars now inside the sidebar (right: 0), not floating outside the border. Verified locally with Playwright — gripRight < sidebarRight.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer-template/pull/124" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
