### PR TITLE
feat: deploy live showcase to GitHub Pages

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -1,0 +1,97 @@
+name: showcase
+
+# Builds the kbexplorer-template SPA (pinned to a release tag) in self-contained
+# local mode and deploys it to GitHub Pages as the docs repo's live showcase:
+#   https://anokye-labs.github.io/kbexplorer/
+#
+# This repo holds no application code (see AGENTS.md). The template is cloned and
+# built in CI only — nothing from it is committed here. Local mode bakes a manifest
+# at build time, so the deployed bundle needs no runtime GitHub token or API calls.
+#
+# Not a required status check: it never gates PRs / auto-merge. It deploys after a
+# merge to main, on demand, or on a daily schedule. NOTE: agent auto-merges are made
+# with GITHUB_TOKEN, which does not emit a `push` event (anti-recursion), so the very
+# first publish after a bot merge comes from `workflow_dispatch` or the daily `schedule`.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+  # Daily rebuild keeps the baked, repo-aware content (issues / PRs) reasonably fresh
+  # at the pinned template tag, and backstops bot merges that emit no `push` event.
+  schedule:
+    - cron: '17 4 * * *'
+
+# The template release tag to build. Bump via a normal issue-first PR when a new
+# template release ships (the template advises host repos to pin to a tag, not main).
+env:
+  TEMPLATE_REPO: anokye-labs/kbexplorer-template
+  TEMPLATE_REF: v0.2.0
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Serialize Pages deploys; never cancel a deploy mid-flight.
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out template (pinned)
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ env.TEMPLATE_REPO }}
+          ref: ${{ env.TEMPLATE_REF }}
+          path: template
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: template/package-lock.json
+
+      - name: Install dependencies
+        working-directory: template
+        run: npm ci
+
+      # Local mode: bake config + authored content + file tree + README + (best-effort)
+      # issues/PRs into src/generated/repo-manifest.json so the bundle is self-contained.
+      - name: Generate manifest
+        working-directory: template
+        run: node scripts/generate-manifest.js
+        env:
+          VITE_KB_LOCAL: 'true'
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Build
+        working-directory: template
+        run: npx vite build
+        env:
+          VITE_KB_LOCAL: 'true'
+          VITE_BASE_PATH: /kbexplorer/
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Copy index.html to 404.html for SPA routing
+        working-directory: template
+        run: cp dist/index.html dist/404.html
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: template/dist
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This repo holds **no application code**. The code lives in:
     not per resource type, and resources carry hypermedia `links`),
   - the provider and representation **extension points** (bring your own local or
     third-party providers and render targets).
-- a deployed **showcase** of kbexplorer (added by a follow-up task).
+- a deployed **showcase** of kbexplorer — the `spa` representation rendering a
+  sample knowledge base in the browser.
+
+## Live showcase
+
+**<https://anokye-labs.github.io/kbexplorer/>** — the
+[`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) SPA,
+built in self-contained local mode over a sample knowledge base and published to
+GitHub Pages from this repo.
 
 > See [`docs/architecture.md`](docs/architecture.md) for the system overview.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,8 @@ A **Representation** renders the pure graph for a target. Interchangeable target
   on context node(s), emits nearest neighbors ranked by edge weight to a budget,
   and emits navigable `kg://` links for relevant-but-unexpanded neighbors. It never
   returns the whole graph.
-- `spa` — the browser explorer (`kbexplorer-template`).
+- `spa` — the browser explorer (`kbexplorer-template`). See the
+  **[live showcase](https://anokye-labs.github.io/kbexplorer/)**.
 
 ## Extension points
 


### PR DESCRIPTION
## What

Stands up a **live showcase** of kbexplorer and links it from the docs.

- Adds `.github/workflows/showcase.yml` — builds the
  [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) SPA
  (pinned to tag **`v0.2.0`**) in self‑contained **local mode**
  (`VITE_KB_LOCAL=true`, `VITE_BASE_PATH=/kbexplorer/`) and deploys it to GitHub
  Pages at **https://anokye-labs.github.io/kbexplorer/**.
- Links the live showcase from `README.md` and `docs/architecture.md`
  (Representation → `spa`).

## Why this approach

- **GitHub Pages, not Azure SWA** — needs **no repository secrets** (`GITHUB_TOKEN`
  + OIDC `id-token`), reuses the template's already‑proven Pages recipe, and fits
  protected‑main + agent auto‑merge (the deploy runs after merge / on a schedule and
  is **not** a required status check, so it never blocks).
- **Local mode** bakes a manifest at build time, so the published bundle makes no
  runtime GitHub API calls and needs no runtime token.
- **Pinned clone** of the template (not a submodule, not a published static artifact —
  none is published). Keeps this repo code‑free (per `AGENTS.md`): the template is
  built in CI only; nothing from it is committed here.
- **Stays current:** daily `schedule` rebuild refreshes the baked repo‑aware content at
  the pinned tag; bump the tag via a normal issue‑first PR when a new template release
  ships.

## ⚠️ Human‑only activation steps (cannot be done by an agent)

1. **Enable GitHub Pages** on `anokye-labs/kbexplorer` with **Source = "GitHub Actions"**
   (currently disabled — `GET /repos/anokye-labs/kbexplorer/pages` → 404).
   Settings → Pages, or `gh api -X POST repos/anokye-labs/kbexplorer/pages -f build_type=workflow`.
2. **First publish:** an agent auto‑merge uses `GITHUB_TOKEN`, which emits no `push`
   event, so trigger the first deploy manually once Pages is enabled —
   `gh workflow run showcase.yml --repo anokye-labs/kbexplorer` (or wait for the daily cron).
3. Confirm the `github-pages` environment allows `main` (default does).

No repository secrets are required.

## Acceptance / verification (after activation)

- `curl -sSI https://anokye-labs.github.io/kbexplorer/` → `200`, plus a hashed
  `/assets/*` file → `200` (base path correct).
- The explorer shell mounts and the constellation graph renders nodes.
- README + architecture links resolve. The showcase link is live **once Pages is
  enabled and the first deploy runs** (steps above).

Closes #3