### PR TITLE
docs: tell the full kbx story — personas, journeys, demand map, and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,22 @@ This repo holds **no application code**. The code lives in:
 - a deployed **showcase** of kbexplorer — the `spa` representation rendering a
   sample knowledge base in the browser.
 
+## The kbx story
+
+Beyond the architecture, this repo tells the **full kbx story** so a reader — or an
+agent — can understand who kbx is for and how it gets built:
+
+- [`docs/personas.md`](docs/personas.md) — the people who use kbx.
+- [`docs/journeys.md`](docs/journeys.md) — end-to-end persona journeys.
+- [`docs/user-stories.md`](docs/user-stories.md) — the user-story **demand map**
+  (families A–K), each story linked to the issue that delivers it.
+- [`docs/roadmap.md`](docs/roadmap.md) — the two programs (foundation + plugin) and the
+  cross-repo, wave-by-wave execution plan.
+
+Together these close the loop: start from a person's need and walk to the code that
+satisfies it, or start from an epic and find who it is for. The work is tracked under
+[#23](https://github.com/anokye-labs/kbexplorer/issues/23).
+
 ## Live showcase
 
 **<https://anokye-labs.github.io/kbexplorer/>** — the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,6 +46,11 @@ flowchart LR
 - [Extension points](#extension-points)
 - [Where things live](#where-things-live)
 
+> **See also — the kbx story:** [personas](personas.md) ·
+> [journeys](journeys.md) · [user-story demand map](user-stories.md) ·
+> [roadmap & program](roadmap.md). This document covers *how kbx is built*; those cover
+> *who it is for and what gets built next*.
+
 ## The one-way dependency rule
 
 The single invariant that makes the system decoupled:

--- a/docs/journeys.md
+++ b/docs/journeys.md
@@ -1,0 +1,165 @@
+# Journeys
+
+A journey is an **end-to-end narrative** for one [persona](personas.md) — the arc from
+where they start to the value they reach. Journeys are how we pressure-test the system
+as a whole: each one must be tellable without hand-waving, and each step must be
+delivered by a tracked issue.
+
+Where a journey says *delivered by*, it links the implementation issues that make the
+step real. The demand-map umbrella is
+[#23](https://github.com/anokye-labs/kbexplorer/issues/23); the two delivery programs
+are the **foundation** ([#13](https://github.com/anokye-labs/kbexplorer/issues/13)) and
+the **plugin** ([#8](https://github.com/anokye-labs/kbexplorer/issues/8)). See the
+[roadmap](roadmap.md) for how these sequence.
+
+| # | Journey | Persona | The crux |
+|---|---|---|---|
+| J1 | Greenfield genesis | Mei / Dana | Empty repo → living KB, with or without the CLI |
+| J2 | Work items into the graph | Priya | A non-GitHub system of record is just a source |
+| J3 | Perforce, no GitHub host | Kenji | Decouple the host; keep git as the backing store |
+| J4 | The no-repo analyst | Noor | No git/Node/terminal — the plugin brokers everything |
+| J5 | Many sources, one graph | Morgan | Connection, not merge (the headline) |
+| J6 | Compliance & governance | Elena | Provenance, access, and approval that travel with the resource |
+| J7 | The non-engineer | Quinn | Make what they already write addressable, time-aware, safe |
+
+---
+
+## J1 — Greenfield genesis
+**Persona:** Mei / Dana · **From an empty repo to a living, queryable, visual KB —
+with or without the CLI.**
+
+Today the only door is `npx @anokye-labs/kbexplorer init`, and it has silent cliffs:
+the visual-mode and theme you pick are discarded, semantic search is never mentioned,
+and first-run failures (no Node 22, no git remote, vendor-mode `npm install` skip) are
+undiscoverable. The plugin should **own the genesis** and turn those cliffs into
+explicit choices.
+
+Genesis is a **state machine, not a surface**: `template strategy → content mode →
+visual identity → search mode → generate`, rendered by any surface. Three paths stay
+distinct:
+
+1. **CLI-first** — Dana runs the CLI; the canvas/MCP attach to the produced artifacts.
+2. **Plugin-first** — Mei never touches the CLI: install + enable the plugin, open the
+   onboarding canvas, and the plugin drives `init`/`generate`/`search-index` locally
+   via the Copilot runtime. *(No CLI **for the user** — not zero-install.)*
+3. **Read-only existing-KB** — point the canvas at a repo that already has a manifest.
+
+**Delivered by:** [#20](https://github.com/anokye-labs/kbexplorer/issues/20) (genesis),
+[#19](https://github.com/anokye-labs/kbexplorer/issues/19) (packaging);
+[kbexplorer-cli#149](https://github.com/anokye-labs/kbexplorer-cli/issues/149) (state
+machine), [#152](https://github.com/anokye-labs/kbexplorer-cli/issues/152) (first-run);
+[kbexplorer-template#428](https://github.com/anokye-labs/kbexplorer-template/issues/428)
+(canvas onboarding).
+
+---
+
+## J2 — Priya: Azure DevOps work items into the graph
+**Persona:** Priya · **A non-GitHub system of record is just another source.**
+
+Priya maps work items, epics, iterations, risks, and ownership from Azure DevOps. ADO
+is ingested through a **generic provider**; identity is source-agnostic (no GitHub
+shape assumed); references carried in ADO content (`AB#1234`, links to repos/PRs)
+resolve to target nodes and become **minted edges**; access labels carry over.
+
+**Delivered by:** [kbexplorer-core#18](https://github.com/anokye-labs/kbexplorer-core/issues/18)
+(identity); [kbexplorer-cli#132](https://github.com/anokye-labs/kbexplorer-cli/issues/132),
+[#135](https://github.com/anokye-labs/kbexplorer-cli/issues/135) (ingestion);
+[#15](https://github.com/anokye-labs/kbexplorer/issues/15) (connection);
+[#17](https://github.com/anokye-labs/kbexplorer/issues/17) (access).
+
+---
+
+## J3 — Kenji: Perforce Helix Core (no GitHub host)
+**Persona:** Kenji · **Decouple the host; keep git as the backing store.**
+
+Kenji works in Perforce — changelists, streams, assets — with no GitHub host. kbx must
+separate *GitHub-the-host* (gh, owner/repo identity, Pages deploy, PR handoff) from the
+engine, while keeping **git** as the optional store. "Affected" becomes a
+changelist/shelf/label range rather than a git diff; the deepest coupling is the
+change-proposal (PR) handoff.
+
+**Delivered by:** [#16](https://github.com/anokye-labs/kbexplorer/issues/16) (decouple
+host: [kbexplorer-cli#141](https://github.com/anokye-labs/kbexplorer-cli/issues/141),
+[#142](https://github.com/anokye-labs/kbexplorer-cli/issues/142));
+[kbexplorer-cli#135](https://github.com/anokye-labs/kbexplorer-cli/issues/135) (provider),
+[#136](https://github.com/anokye-labs/kbexplorer-cli/issues/136) (affected dispatch).
+
+---
+
+## J4 — Noor: the no-repo analyst
+**Persona:** Noor · **No git, no Node, no terminal — the plugin brokers everything.**
+
+Noor imports from Confluence / Notion / Drive and wants queryable org context but has
+none of the developer scaffolding. The plugin must broker a **plugin-first genesis**; a
+**GraphStore** (not a committed repo) holds state; non-GitHub sources are first-class.
+This is the strongest test of "usable without the CLI."
+
+**Delivered by:** [#20](https://github.com/anokye-labs/kbexplorer/issues/20)
+(plugin-first genesis);
+[kbexplorer-cli#135](https://github.com/anokye-labs/kbexplorer-cli/issues/135) (provider);
+[kbexplorer-template#382](https://github.com/anokye-labs/kbexplorer-template/issues/382)
+(GraphStore); [#16](https://github.com/anokye-labs/kbexplorer/issues/16) (host-decouple).
+
+---
+
+## J5 — Morgan: many sources, one graph (the headline)
+**Persona:** Morgan · **Connection, not merge.**
+
+Morgan maintains teams, systems, owners, missions, and decisions across **multiple**
+sources. The headline value is *many sources → one graph* — but not by merging
+duplicate records. Three operations: **mint reference edges** between distinct
+artifacts (a Confluence doc *describes* a GitHub epic; a PR *implements* an ADO work
+item); **conflate referents** (the same person/team/service under several native IDs
+collapses to one node with multiple source-pointers); and **declare source precedence**
+for the rare conflicting fact. No confidence-threshold auto-merge.
+
+**Delivered by:** [#15](https://github.com/anokye-labs/kbexplorer/issues/15)
+(connection); [kbexplorer-core#18](https://github.com/anokye-labs/kbexplorer-core/issues/18)
+(identity); [kbexplorer-cli#132](https://github.com/anokye-labs/kbexplorer-cli/issues/132)
+(ingestion).
+
+---
+
+## J6 — Elena: compliance & governance
+**Persona:** Elena · **Trust that travels with the resource.**
+
+Elena audits provenance, stale decisions, approvals, and access boundaries across a
+unified KB. She needs first-class **provenance** (observed vs derived, sources,
+generator), **access labels** that travel with the resource (kbx labels; the host
+enforces), a **human approval gate** for generated content, and **consent + cost
+disclosure** for the sampling bridge.
+
+**Delivered by:** [#17](https://github.com/anokye-labs/kbexplorer/issues/17) (access);
+[kbexplorer-core#23](https://github.com/anokye-labs/kbexplorer-core/issues/23),
+[#24](https://github.com/anokye-labs/kbexplorer-core/issues/24) (provenance/derivation);
+[kbexplorer-cli#155](https://github.com/anokye-labs/kbexplorer-cli/issues/155) (consent);
+[kbexplorer-template#429](https://github.com/anokye-labs/kbexplorer-template/issues/429)
+(review).
+
+---
+
+## J7 — Quinn: the non-engineer knowledge worker
+**Persona:** Quinn · **Meet them where they are.**
+
+Quinn lives in a spreadsheet, builds the deck, iterates the doc. A resource-oriented
+model — articulated in
+[#12's discussion](https://github.com/anokye-labs/kbexplorer/issues/12) — makes the
+structured part of what Quinn already writes:
+
+- **addressable** — one thing, one address; many views. Stop hand-reconciling the doc,
+  the sheet, and the slide as three drifting copies.
+- **navigable** — follow meaning, not folders, because the links *are* the structure.
+- **time-aware** — the system remembers *when*, not just *what* ("what did we commit to
+  in C1" vs "what did we believe at the time").
+- **safe to change** — a change is a reviewable **proposal** routed to the right
+  authority, not a silent clobber; the system tells you in the moment what you may
+  change, and the data explains its own vocabulary and constraints.
+
+Judgment stays human; plumbing goes to agents that can only do what a resource
+advertises.
+
+**Delivered by:** [kbexplorer-core#18](https://github.com/anokye-labs/kbexplorer-core/issues/18)
+(identity); content negotiation (story D9) and advertised-operations safety (story E8)
+in the [demand map](user-stories.md); the **Time & provenance** family (K); propose/review
+via [kbexplorer-cli#142](https://github.com/anokye-labs/kbexplorer-cli/issues/142) +
+[kbexplorer-template#429](https://github.com/anokye-labs/kbexplorer-template/issues/429).

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -1,0 +1,123 @@
+# The people who use kbx
+
+kbx turns scattered organizational knowledge — issues, docs, work items, decisions,
+people, services — into **one navigable, queryable graph**, stored in git and
+rendered through pluggable surfaces. This page introduces the **cast**: the personas
+referenced throughout the [journeys](journeys.md) and the [user-story demand
+map](user-stories.md).
+
+Personas are not roles in a permission system; they are *who shows up and what they
+are trying to do*. They exist so that every capability we build can be checked against
+a real human need — and so that claims like "works for non-GitHub sources" or "usable
+without the CLI" have someone concrete to fail.
+
+| Persona | In one line | Touches the CLI? | Drives |
+|---|---|---|---|
+| **Dana** | KB owner / author | Yes | Genesis, curation, generation |
+| **Ravi** | Developer / contributor | Sometimes | Incidental nodes, refresh |
+| **Mei** | Newcomer / learner | **Never** | Sense-making, search |
+| **Lena** | Lead / reviewer | Rarely | Freshness, cross-cutting questions |
+| **Copilot** | The agent | n/a (it *is* a client) | Grounded answers, actions, the do-seam |
+| **Sam** | Plugin / platform operator | Yes | Install, distribute, wire credentials |
+| **Noor** | Confluence analyst | **No git / Node / terminal** | Non-repo genesis, import |
+| **Morgan** | Org modeler | Yes | Multi-source unification (the headline) |
+| **Priya** | Azure DevOps / Jira operator | Yes | Work-item ingestion |
+| **Kenji** | Perforce Helix Core dev | Yes (p4, not git host) | Host-decoupling |
+| **Elena** | Compliance / governance | Rarely | Provenance, access, approvals |
+| **Quinn** | Non-engineer knowledge worker | **Never** | One-address truth, propose-don't-overwrite |
+
+---
+
+## The core cast
+
+### Dana — KB owner / author
+Curates the structure of the knowledge base, runs `generate`, and owns the visual
+identity and correctness of the result. Dana decides the template strategy and the
+node-type model. When the KB looks wrong or goes stale, it is Dana's problem.
+**Primary journeys:** [greenfield genesis](journeys.md#j1-greenfield-genesis).
+
+### Ravi — developer / contributor
+Lives in the repository and wants the KB to stay current with his pull requests. Ravi
+contributes nodes *incidentally* — a code change spawns or updates a node — rather
+than sitting down to author the graph. He cares that refresh is cheap and that the KB
+never silently rots.
+
+### Mei — newcomer / learner
+**Never touches the CLI.** Mei makes sense of an unfamiliar system through search,
+focused reading views, and the constellation — starting from an anchor, not a
+hairball. Mei is the test for "usable without the terminal": if a capability requires
+`npx`, Mei cannot reach it.
+
+### Lena — lead / reviewer
+Asks cross-cutting questions across clusters, wants freshness and health signals, and
+relies on decision records. Lena reads the KB to make decisions; she rarely edits it.
+
+### Copilot — the agent
+A first-class actor, not a bystander. Copilot consumes the KB as grounded context,
+drives the canvas through actions, calls the [MCP do-seam](roadmap.md) tools, and can
+be handed work — but only the work a resource *advertises*. Copilot is the reason the
+"do-seam" and the consent rules exist.
+
+### Sam — plugin / platform operator
+Installs and distributes the plugin across repos and scopes, wires the MCP
+configuration and credentials (bring-your-own `gh` and provider keys), and runs the
+surfaces. Sam is who the distribution and `doctor`/preflight stories serve.
+
+---
+
+## The non-GitHub fleet
+
+These personas exist to keep kbx honest about its generality. Every "open kind / open
+affordance / any source" claim is tested against them. If a journey for these people
+cannot be written without GitHub-specific assumptions, the generality is aspirational.
+
+### Noor — Confluence analyst
+Imports from Confluence / Notion / Drive and wants queryable org context — but may
+have **no git, no Node, and no terminal at all**. Noor breaks the CLI-first genesis at
+step one and forces the *plugin-brokered* path (and a backing store that is not a
+committed repo).
+
+### Morgan — org modeler
+Maintains teams, systems, owners, missions, and decisions across **multiple** sources.
+Morgan is the headline use case: *many sources → one graph* by **connection, not
+merge** — minting reference edges between distinct artifacts and conflating shared
+people/teams/services.
+
+### Priya — Azure DevOps / Jira operator
+Maps work items, epics, iterations, risks, and ownership from Azure DevOps / Jira.
+Priya proves that a non-GitHub system of record is just another source through a
+generic provider.
+
+### Kenji — Perforce Helix Core developer
+Works in Perforce — no GitHub host. Changelists, streams, and assets; "affected" is a
+changelist/shelf/label range, not a git diff. Kenji proves the host can be decoupled
+while git stays the optional backing store.
+
+### Elena — compliance / governance
+Audits provenance, stale decisions, approvals, and access boundaries. A *unified* KB
+is a new, broader access boundary — Elena is the reason access is labeled, generated
+content needs a human approval gate, and the sampling bridge needs consent + cost
+disclosure.
+
+---
+
+## The non-engineer
+
+### Quinn — knowledge worker
+Lives in the spreadsheet, builds the deck, iterates the doc. Quinn is not an engineer
+and never will be. The Resource-Oriented framing in [#12's
+discussion](https://github.com/anokye-labs/kbexplorer/issues/12) is, at heart, *for
+Quinn*: make the structured part of what Quinn already writes **addressable** (one
+thing, one address — stop reconciling the doc, the sheet, and the slide),
+**navigable** (follow meaning, not folders), **time-aware** (the system remembers
+*when*, not just *what*), and **safe to change** (propose, don't overwrite). The tool
+meets Quinn where they are.
+
+---
+
+## Where personas show up
+
+- Each persona drives one or more end-to-end [journeys](journeys.md).
+- Each [user story](user-stories.md) names the persona it serves.
+- The work that delivers each story is tracked under the demand-map umbrella
+  [#23](https://github.com/anokye-labs/kbexplorer/issues/23).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,116 @@
+# Roadmap & program
+
+kbx is built as **two peer programs** over one engine, sequenced by a single
+cross-repo, wave-by-wave plan. This page is the map; the authoritative, living detail
+is in the linked issues.
+
+- **Foundation** (substrate) — [#13](https://github.com/anokye-labs/kbexplorer/issues/13):
+  *many sources → one trustworthy graph, stored in git.*
+- **Plugin** (surface) — [#8](https://github.com/anokye-labs/kbexplorer/issues/8):
+  *a Copilot plugin — commands + agents + skill + canvas + MCP — over that graph.*
+- **Demand map** — [#23](https://github.com/anokye-labs/kbexplorer/issues/23): the
+  [user stories](user-stories.md) and [journeys](journeys.md) the programs serve.
+- **Execution plan** — [#90](https://github.com/anokye-labs/kbexplorer/issues/90): the
+  full wave-by-wave sequence (rubber-duck validated). The summary below tracks it.
+- **Requirements & vision** — [#12](https://github.com/anokye-labs/kbexplorer/issues/12).
+
+> **North star:** the bespoke Copilot canvas renders **and acts on** a trustworthy,
+> heterogeneous-source KBGraph — provenance-bearing, identity-unified, access-labeled —
+> all stored in git.
+
+---
+
+## The two programs
+
+### Foundation — [#13](https://github.com/anokye-labs/kbexplorer/issues/13)
+
+| Epic | What | Repo |
+|---|---|---|
+| **E1** [core#18](https://github.com/anokye-labs/kbexplorer-core/issues/18) | Configurable, source-agnostic identity + provenance. **The precursor.** | kbexplorer-core |
+| **E2** [cli#132](https://github.com/anokye-labs/kbexplorer-cli/issues/132) | File-based ingestion + providers | kbexplorer-cli |
+| **E3** [#15](https://github.com/anokye-labs/kbexplorer/issues/15) | Cross-source **connection** (edge-mint, conflation, precedence) | cli (+ thin core) |
+| **E4** [#16](https://github.com/anokye-labs/kbexplorer/issues/16) | Decouple GitHub-the-host (git stays the store) | cli + template |
+| **E5** [#17](https://github.com/anokye-labs/kbexplorer/issues/17) | Access labeling (kbx labels; host enforces) | core + consumers |
+| **E6** [template#426](https://github.com/anokye-labs/kbexplorer-template/issues/426) | Representation — rich-Markdown rendering + lenses | kbexplorer-template |
+
+### Plugin — [#8](https://github.com/anokye-labs/kbexplorer/issues/8)
+
+| Sub-tree | What | Repo |
+|---|---|---|
+| **Rendering** [template#401](https://github.com/anokye-labs/kbexplorer-template/issues/401) / [#407](https://github.com/anokye-labs/kbexplorer-template/issues/407) | Host-themeable canvas + the bespoke agent-driven surface | template (+ core#15/#16) |
+| **PE1** [#19](https://github.com/anokye-labs/kbexplorer/issues/19) | Plugin packaging + command surface | cli |
+| **PE2** [#20](https://github.com/anokye-labs/kbexplorer/issues/20) | Guided genesis / onboarding | cli + template |
+| **PE3** [#21](https://github.com/anokye-labs/kbexplorer/issues/21) | MCP do-seam + job layer + consent | cli |
+| **PE4** [#22](https://github.com/anokye-labs/kbexplorer/issues/22) | Source-drift + generated-content review | cli + template |
+
+```mermaid
+graph TD
+  E1["E1 core identity + provenance<br/>(PRECURSOR)"]
+  E2["E2 ingestion"]
+  E3["E3 connection"]
+  E5["E5 access"]
+  E6["E6 representation"]
+  E4["E4 decouple host<br/>(parallel)"]
+  PLUG["#8 plugin program<br/>(rendering + PE1-PE4)"]
+  E1 --> E2
+  E1 --> E3
+  E1 --> E5
+  E1 --> E6
+  E2 --> E3
+  E1 -. host-neutral identity type .-> E4
+  E1 --> PLUG
+  E3 --> PLUG
+  E5 --> PLUG
+  E6 --> PLUG
+```
+
+The plugin **consumes** the foundation: the bespoke canvas reuses the Representation
+seam, host-neutral identity, connection edges, and access labels rather than
+re-deriving them.
+
+---
+
+## Critical path
+
+```
+E1.P1 (ship kbexplorer-core release)
+   → cli#133 (rich-Markdown provider)
+   → cli#134 (composite ingestion)
+   → cli#136 (affected-dispatch)  (+ core#25 identity claims)
+   → E3  (cli#137–#140 connection)
+```
+
+Everything else — E4 entirely, E5, E1's later phases, breadth adapters, the plugin
+spine — rides parallel lanes off this spine. The `E1 → {E2, E3, E5}` and
+`PE3 → MCP` edges are **package-release gates**: consumers code against a *published*
+kbexplorer-core, not an unmerged branch.
+
+---
+
+## Waves (summary of [#90](https://github.com/anokye-labs/kbexplorer/issues/90))
+
+| Wave | Lands | Gated on |
+|---|---|---|
+| **0a — Core unlock** | E1.P1 (core#19/#20/#21/#22) → **core release**; parallel cli#141, core#15/#16 | nothing |
+| **0b — First visible slice** | cli#133, template#427, showcase #14 | 0a release |
+| **1 — Plugin spine + theming** | PE3 cli#153/#156, PE1 cli#145/#146, theming template#402–404; E1 core#23/#24 | 0a (+ template#427 for theming) |
+| **2 — Ingest + label + job layer + bespoke skeleton + early genesis** | cli#134→#136, PE1 cli#147, PE3 cli#154, #407 skeleton, E5 core#28→cli#144, PE2 cli#149/#150/#152, E1 core#25/#26/#27 | W1 |
+| **3 — Connect + governance + genesis surface** | **E3 cli#137–#140**, search#9→cli#151, core#29, template#428, PE3 cli#155, #407 rest | W2 |
+| **4 — Trust loop + host breadth + polish** | E4.P2–4, PE4 (drift→review), cli#135, cli#148, #8 thin surfacing | W3 |
+
+**Backlog — candidate new epic E7 (Time & provenance):** bitemporal + as-of + PROV-O
+propagation. Demand is the [**K** story family](user-stories.md#k--time--provenance-semantic-space-time)
+([#32](https://github.com/anokye-labs/kbexplorer/issues/32)), surfaced by
+[#12](https://github.com/anokye-labs/kbexplorer/issues/12)'s discussion. This is
+**genuinely new core work** not covered by E1–E6 and needs its own epic before
+scheduling.
+
+---
+
+## Demand → supply traceability
+
+Every [user story](user-stories.md) names the issue(s) that deliver it; every
+foundation/plugin epic traces back to the requirements in
+[#12](https://github.com/anokye-labs/kbexplorer/issues/12). The result is a closed
+loop: a reader (human or agent) can start from *a person's need* and walk to *the code
+that satisfies it*, or start from *an epic* and find *who it is for*.

--- a/docs/user-stories.md
+++ b/docs/user-stories.md
@@ -1,0 +1,110 @@
+# User stories — the demand map
+
+This is the **demand side** of kbx: what people need, expressed as user stories and
+grouped into families. The **supply side** — the work that delivers them — lives in the
+two programs (**foundation**
+[#13](https://github.com/anokye-labs/kbexplorer/issues/13) and **plugin**
+[#8](https://github.com/anokye-labs/kbexplorer/issues/8)) and is sequenced by the
+[roadmap](roadmap.md). Every story below links both to its **tracking issue** (under
+the demand-map umbrella [#23](https://github.com/anokye-labs/kbexplorer/issues/23)) and
+to the issue(s) that **deliver** it, so coverage is traceable in both directions.
+
+Personas are introduced in [personas.md](personas.md); end-to-end arcs in
+[journeys.md](journeys.md).
+
+**Locus** legend — *where the capability mainly lives*: **C** = core contract ·
+**S** = shared interaction layer · **U** = surface UX. Locus is not cost: the rendering
+seam is cheap; genesis, write-back, the affordance launchpad, and the credential/agent
+plumbing are the real investment.
+
+---
+
+## A — Genesis (stand up a KB) · [#24](https://github.com/anokye-labs/kbexplorer/issues/24)
+
+- **A1 — Cold-start guided init** ([#34](https://github.com/anokye-labs/kbexplorer/issues/34)) · *As Mei/Dana, I want a guided cold-start from an empty repo, so that I reach a living, queryable KB without the terminal.* · **U** · delivers: #20, cli#149/#152, template#428.
+- **A2 — Choose template strategy** ([#35](https://github.com/anokye-labs/kbexplorer/issues/35)) · *…choose submodule/vendor/custom/ref, recorded in `.kbx.json`, so that I control the upgrade path.* · **C** · delivers: cli#149.
+- **A3 — Persist visual identity + theme** ([#36](https://github.com/anokye-labs/kbexplorer/issues/36)) · *…the visual-mode + theme I pick to persist, so that my KB looks the way I chose.* · **C/bugfix** · delivers: cli#150, core#15.
+
+## B — Grow & curate · [#25](https://github.com/anokye-labs/kbexplorer/issues/25)
+
+- **B1 — Add a node by hand** ([#37](https://github.com/anokye-labs/kbexplorer/issues/37)) · **S** · delivers: cli#133, template#427.
+- **B2 — Incidental node from a code change** ([#38](https://github.com/anokye-labs/kbexplorer/issues/38)) · **C** · delivers: cli#136/#158.
+- **B3 — Connect two nodes with a typed relation** ([#39](https://github.com/anokye-labs/kbexplorer/issues/39)) · **S/C** · delivers: core#27.
+- **B4 — New node type + bespoke viewer** ([#40](https://github.com/anokye-labs/kbexplorer/issues/40)) · **C+U** · delivers: template#147, cli#148.
+- **B5 — Curate clusters & structure** ([#41](https://github.com/anokye-labs/kbexplorer/issues/41)) · **S** · delivers: template#147/#54.
+- **B6 — Generate content for a stub via an agent** ([#42](https://github.com/anokye-labs/kbexplorer/issues/42)) · **C** · delivers: cli#147, template#429.
+
+## C — Keep healthy & current · [#26](https://github.com/anokye-labs/kbexplorer/issues/26)
+
+- **C1 — Incremental refresh after a code change** ([#43](https://github.com/anokye-labs/kbexplorer/issues/43)) · **C** · delivers: cli#136/#158.
+- **C2 — Freshness & staleness signals** ([#44](https://github.com/anokye-labs/kbexplorer/issues/44)) · **S** · delivers: cli#157.
+- **C3 — CI gates drift** ([#45](https://github.com/anokye-labs/kbexplorer/issues/45)) · **C** · delivers: cli#140/#151.
+- **C4 — Audit structural integrity** ([#46](https://github.com/anokye-labs/kbexplorer/issues/46)) · **C** · delivers: core#18.
+- **C5 — Update template version safely** ([#47](https://github.com/anokye-labs/kbexplorer/issues/47)) · **C** · delivers: cli#42/#117.
+- **C6 — Validate a proposed change against a shape** ([#74](https://github.com/anokye-labs/kbexplorer/issues/74)) · *…against a declared SHACL/ShEx shape before commit, so that invalid data never lands and the data explains its own constraints.* · **C/S** · delivers: new validation work; template#429. *(from [#12](https://github.com/anokye-labs/kbexplorer/issues/12) comments)*
+
+## D — Make sense of it · [#27](https://github.com/anokye-labs/kbexplorer/issues/27)
+
+- **D1 — Explore the constellation** ([#48](https://github.com/anokye-labs/kbexplorer/issues/48)) · **U** · delivers: template#401/#408.
+- **D2 — Focused reading view** ([#49](https://github.com/anokye-labs/kbexplorer/issues/49)) · **U** · delivers: template#426/#412.
+- **D3 — Semantic, graph-aware search** ([#50](https://github.com/anokye-labs/kbexplorer/issues/50)) · **S** · delivers: template#344, cli#151.
+- **D4 — Follow relations hop-by-hop** ([#51](https://github.com/anokye-labs/kbexplorer/issues/51)) · **S** · delivers: template#409.
+- **D5 — Copilot answers grounded in the KB** ([#52](https://github.com/anokye-labs/kbexplorer/issues/52)) · **S** · delivers: cli#153.
+- **D6 — Node-type-specific viewer** ([#53](https://github.com/anokye-labs/kbexplorer/issues/53)) · **U** · delivers: template#412/#147.
+- **D7 — Cross-cutting question across clusters** ([#54](https://github.com/anokye-labs/kbexplorer/issues/54)) · **S** · delivers: template#344, cli#153.
+- **D8 — Home/anchor orientation view** ([#55](https://github.com/anokye-labs/kbexplorer/issues/55)) · **U** · delivers: template#408.
+- **D9 — Request a resource in a chosen representation** ([#75](https://github.com/anokye-labs/kbexplorer/issues/75)) · *…via content negotiation (spa/json-ld/llm-context/canvas), so that one resource serves many views.* · **S** · delivers: cli#92/#93, core#16. *(from #12 comments)*
+
+## E — Affordance-aware actions on any node · [#28](https://github.com/anokye-labs/kbexplorer/issues/28)
+
+> "Act on it" is **affordance-generic**, not issue/PR. Issue/PR are one instance of an
+> open affordance model — never the frame.
+
+- **E1 — See affordances on any node** ([#56](https://github.com/anokye-labs/kbexplorer/issues/56)) · **C/S** · delivers: template#411.
+- **E2 — Edit a content node + stage write-back** ([#57](https://github.com/anokye-labs/kbexplorer/issues/57)) · **C** · delivers: cli#142.
+- **E3 — Act on a work node (one affordance instance)** ([#58](https://github.com/anokye-labs/kbexplorer/issues/58)) · **C** · delivers: cli#142.
+- **E4 — Derive nodes from an arbitrary source** ([#59](https://github.com/anokye-labs/kbexplorer/issues/59)) · **C** · delivers: cli#135.
+- **E5 — Agent acts via the canvas click→chat bridge** ([#60](https://github.com/anokye-labs/kbexplorer/issues/60)) · **U** · delivers: template#410.
+- **E6 — Trigger an agent task from a node** ([#61](https://github.com/anokye-labs/kbexplorer/issues/61)) · **S** · delivers: template#409, cli#154.
+- **E7 — Scaffold new structure from a node** ([#62](https://github.com/anokye-labs/kbexplorer/issues/62)) · **C** · delivers: cli#146.
+- **E8 — Agent acts only on advertised operations** ([#76](https://github.com/anokye-labs/kbexplorer/issues/76)) · *…in-band (HATEOAS/Hydra), so that handing work to an agent is trustworthy by construction.* · **C/S** · delivers: template#411, cli#155. *(from #12 comments)*
+
+## F — KB as context & export · [#29](https://github.com/anokye-labs/kbexplorer/issues/29)
+
+- **F1 — Token-budgeted llm-context pack** ([#63](https://github.com/anokye-labs/kbexplorer/issues/63)) · **C** · delivers: cli#92/#153.
+- **F2 — Export JSON-LD for interop** ([#64](https://github.com/anokye-labs/kbexplorer/issues/64)) · **C** · delivers: cli#92/#93.
+- **F3 — Expose the KB as MCP tools** ([#65](https://github.com/anokye-labs/kbexplorer/issues/65)) · **C** · delivers: cli#153.
+
+## G — Operate · [#30](https://github.com/anokye-labs/kbexplorer/issues/30)
+
+- **G1 — Install & distribute the plugin** ([#66](https://github.com/anokye-labs/kbexplorer/issues/66)) · **U** · delivers: cli#145.
+- **G2 — Wire MCP config + credentials** ([#67](https://github.com/anokye-labs/kbexplorer/issues/67)) · **U/ops** · delivers: cli#156.
+- **G3 — doctor / preflight verifies setup** ([#68](https://github.com/anokye-labs/kbexplorer/issues/68)) · **C** · delivers: cli#152/#100.
+- **G4 — Opt into search; build + commit index** ([#69](https://github.com/anokye-labs/kbexplorer/issues/69)) · **C** · delivers: cli#151, template#344.
+- **G5 — Run surfaces with one lifecycle** ([#70](https://github.com/anokye-labs/kbexplorer/issues/70)) · **U/ops** · delivers: cli#131, template#423.
+
+## H — Sync & trust · [#31](https://github.com/anokye-labs/kbexplorer/issues/31)
+
+- **H1 — Stay in sync with the source (drift loop)** ([#71](https://github.com/anokye-labs/kbexplorer/issues/71)) · **S/C** · delivers: cli#157/#158/#159.
+- **H2 — Review generated content before publish** ([#72](https://github.com/anokye-labs/kbexplorer/issues/72)) · **C/S/U** · delivers: template#429, cli#158/#155.
+- **H3 — Multi-repo / org-level genesis** ([#73](https://github.com/anokye-labs/kbexplorer/issues/73)) · **S** · delivers: cli#10/#11, #20.
+
+## K — Time & provenance (semantic space-time) · [#32](https://github.com/anokye-labs/kbexplorer/issues/32)
+
+> From [#12](https://github.com/anokye-labs/kbexplorer/issues/12)'s discussion: a
+> bitemporal + PROV-O model. **K1–K3 are new core work** not yet in E1–E6 — a candidate
+> new epic; these stories are the demand signal for it.
+
+- **K1 — Bitemporal facts (valid time vs recorded time)** ([#77](https://github.com/anokye-labs/kbexplorer/issues/77)) · *…so that future-valid and backdated facts are ordinary, not special cases.* · **C (new)** · aligns core#24.
+- **K2 — As-of queries (time travel)** ([#78](https://github.com/anokye-labs/kbexplorer/issues/78)) · *…what we believed/committed as of time t, so that planning and audit stop being archaeology.* · **C/S (new)**.
+- **K3 — Future-valid & backdated facts** ([#79](https://github.com/anokye-labs/kbexplorer/issues/79)) · **C (new)**.
+- **K4 — Honest derivation that propagates** ([#80](https://github.com/anokye-labs/kbexplorer/issues/80)) · *…along `wasDerivedFrom`, flagging stale dependents without deleting history.* · **C** · delivers: core#24, cli#157/#158.
+- **K5 — Provenance & citations on every fact** ([#81](https://github.com/anokye-labs/kbexplorer/issues/81)) · **C** · delivers: core#23/#24.
+
+---
+
+## Journeys
+
+The end-to-end persona narratives (J1–J7) are tracked under
+[#33](https://github.com/anokye-labs/kbexplorer/issues/33) and told in
+[journeys.md](journeys.md).


### PR DESCRIPTION
## What

Makes the kbexplorer repo **self-describing** — so a reader, or an agent, can analyze kbx by reading the repo. Adds four cross-linked documentation pages:

- **`docs/personas.md`** — the 11 people who use kbx (Dana, Ravi, Mei, Lena, Copilot, Sam; the non-GitHub fleet Noor/Morgan/Priya/Kenji/Elena; and Quinn, the non-engineer).
- **`docs/journeys.md`** — the 7 end-to-end persona journeys (greenfield genesis + the five non-GitHub fleet journeys + Quinn), each linking the issues that deliver it.
- **`docs/user-stories.md`** — the **demand map**: families A–K, every story linked to its tracking issue under #23 and to the work that delivers it.
- **`docs/roadmap.md`** — the two programs (foundation #13 / E1–E6 and plugin #8 / PE1–PE4), the critical path, and the wave-by-wave plan (#90).

Also wires the new pages into the README and the architecture doc's contents.

## Why

The repo documented the *architecture* only. This adds *who kbx is for and what gets built next*, closing the demand→supply loop: start from a person's need and walk to the code that satisfies it, or start from an epic and find who it serves.

## Notes

- Docs-only; no application code (per AGENTS.md). Pages link to the canonical contracts in `kbexplorer-core` rather than restating types.
- All internal links verified to resolve; the showcase build is unaffected.

Closes #89