### PR TITLE
showcase: render this repo as the KB host with a rich-Markdown demo

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -26,7 +26,7 @@ on:
 # template release ships (the template advises host repos to pin to a tag, not main).
 env:
   TEMPLATE_REPO: anokye-labs/kbexplorer-template
-  TEMPLATE_REF: v0.2.0
+  TEMPLATE_REF: v0.3.0
 
 permissions:
   contents: read
@@ -50,6 +50,13 @@ jobs:
           ref: ${{ env.TEMPLATE_REF }}
           path: template
 
+      # This (showcase) repo is the content HOST: its `content/` is rendered as the
+      # knowledge base. The template reads it via VITE_KB_HOST_ROOT (set below).
+      - name: Check out showcase host content
+        uses: actions/checkout@v7
+        with:
+          path: host
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -67,6 +74,7 @@ jobs:
         run: node scripts/generate-manifest.js
         env:
           VITE_KB_LOCAL: 'true'
+          VITE_KB_HOST_ROOT: ${{ github.workspace }}/host
           GH_TOKEN: ${{ github.token }}
 
       - name: Build
@@ -74,6 +82,7 @@ jobs:
         run: npx vite build
         env:
           VITE_KB_LOCAL: 'true'
+          VITE_KB_HOST_ROOT: ${{ github.workspace }}/host
           VITE_BASE_PATH: /kbexplorer/
           GH_TOKEN: ${{ github.token }}
 

--- a/content/org/platform.md
+++ b/content/org/platform.md
@@ -1,0 +1,41 @@
+---
+display: rich-markdown
+title: Platform
+entityType: system
+owner: platform-team
+status: active
+tags: [platform, infrastructure, demo]
+---
+
+# Platform
+
+The **Platform** is the shared backbone the rest of the organization builds on —
+the services, gateways, and data stores that product teams depend on rather than
+re-implement. This page is a live demonstration of kbexplorer's **rich-Markdown**
+slice: the facts in the frontmatter above render as a structured panel, the prose
+renders as a reading view, and the embedded diagram below is rendered live from
+this document's source.
+
+## Shape of the system
+
+```mermaid
+graph TD
+  Client[Client Apps] --> Gateway[API Gateway]
+  Gateway --> Platform[Platform Service]
+  Platform --> Store[(Datastore)]
+  Platform --> Events[[Event Bus]]
+  Events --> Workers[Async Workers]
+```
+
+The gateway fronts every request; the Platform Service owns the core domain and
+persists to the datastore; long-running work is handed to async workers over the
+event bus.
+
+## How this renders
+
+This document opts into rich-Markdown rendering with `display: rich-markdown` in
+its frontmatter. At build time kbexplorer's rich-Markdown **provider** ingests it
+into a graph node — lifting the frontmatter into structured facts, extracting the
+fenced diagram as an embedded block, and resolving typed links to edges. The SPA's
+rich-Markdown **representation** then composes those parts into the view you are
+reading. One document; many faithful views over the same pure graph.


### PR DESCRIPTION
## What

Lights up the **first end-to-end rich-Markdown slice** on the live showcase, and makes the showcase render **this repo's own content** as the knowledge base (the real adopter pattern).

- **`content/org/platform.md`** — a demo document that opts into rich-Markdown rendering (`display: rich-markdown`), with frontmatter facts + a live Mermaid diagram + a typed link.
- **`.github/workflows/showcase.yml`**:
  - checks out this repo as the content **host** and points the template at it via `VITE_KB_HOST_ROOT`;
  - bumps `TEMPLATE_REF` `v0.2.0` → `v0.3.0` (the template release carrying rich-Markdown rendering #427 + authored ingestion #432).

## How it works (the full slice, through the proper seams)

1. `generate-manifest` reads this repo's `content/` (host root) into the manifest's authored content.
2. The template's `AuthoredRichMarkdownProvider` ingests the `display: rich-markdown` doc — via the standalone `@anokye-labs/kbexplorer-provider-rich-markdown` package's pure `./lib` — into a graph node with `data.richMarkdown.blocks`.
3. The rich-Markdown representation renders it: frontmatter as a structured facts panel, prose as a reading view, and the Mermaid block live.

## Verification

Verified the chain locally against template `v0.3.0`: with `VITE_KB_HOST_ROOT` pointed at a host containing `content/org/platform.md`, `generate-manifest` ingests it into `authoredContent` with `display: rich-markdown` preserved, and `vite build` succeeds. Provider ingestion + render are covered by the template's own tests (#432).

The `showcase` workflow deploys on merge to `main` (and on schedule), so the live site updates after this merges.

Closes #14