### PR TITLE
chore: bump showcase TEMPLATE_REF v0.3.0 → v0.4.0

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -26,7 +26,7 @@ on:
 # template release ships (the template advises host repos to pin to a tag, not main).
 env:
   TEMPLATE_REPO: anokye-labs/kbexplorer-template
-  TEMPLATE_REF: v0.3.0
+  TEMPLATE_REF: v0.4.0
 
 permissions:
   contents: read


### PR DESCRIPTION
Bumps the pinned template release the showcase builds from in `.github/workflows/showcase.yml` (`TEMPLATE_REF: v0.3.0` → `v0.4.0`). v0.4.0 is the current Latest release of `anokye-labs/kbexplorer-template`. One-line CI ref bump only — this repo holds no application code.

Closes #98