### PR TITLE
docs: architecture do-seam section, surfaces, verified history, decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,18 +8,40 @@ This repo holds **no application code**. The code lives in:
   contracts (types, `kg://` identity, relation taxonomy, JSON-LD helpers, and the
   Source / Provider / Representation interfaces).
 - [`kbexplorer-cli`](https://github.com/anokye-labs/kbexplorer-cli) — the CLI that
-  derives content and drives the explorer.
+  derives content, drives the explorer, and serves the embeddable Copilot canvas.
 - [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) — the
-  SPA that renders a knowledge graph in the browser.
+  SPA that renders a knowledge graph in the browser (and, additively, the
+  embeddable canvas entry).
+- [`kbexplorer-search`](https://github.com/anokye-labs/kbexplorer-search) — the
+  semantic-search companion module, driven through the CLI.
+- [`kbexplorer-provider-rich-markdown`](https://github.com/anokye-labs/kbexplorer-provider-rich-markdown) —
+  the loadable provider that ingests a rich-Markdown document into a graph
+  fragment.
 
 ## What's here
 
-- `docs/` — the architecture documentation:
+- [`docs/architecture.md`](docs/architecture.md) — the architecture documentation:
   - the four layers — **Sources → Providers → Engine → Representation**,
   - the source / affordance model (affordances are advertised **per retrieval**,
     not per resource type, and resources carry hypermedia `links`),
+  - the **do-seam** — the protocol-neutral affordance action layer and its
+    three interchangeable delivery adapters (extension-tool, MCP, canvas),
   - the provider and representation **extension points** (bring your own local or
     third-party providers and render targets).
+- [`docs/surfaces.md`](docs/surfaces.md) — the **two render surfaces** over the
+  same graph: the human-facing SPA showcase (GitHub Pages) and the
+  agent-facing embeddable Copilot canvas (served by `kbexplorer-cli` over a
+  loopback server). They are different Representation targets, not two
+  versions of one product.
+- [`docs/history.md`](docs/history.md) — a verified, dated changelog across all
+  five repos, plus an honest "what's actually shipped vs. designed" status.
+- [`docs/decisions/`](docs/decisions/) — design decisions worth preserving:
+  [connect-not-merge for cross-source data](docs/decisions/conflation-correction.md)
+  (decided, shipped) and an
+  [open question on rich-Markdown-by-default](docs/decisions/markdown-rendering-default.md)
+  (explicitly **not** decided).
+- [`docs/canvas-dev-loop.md`](docs/canvas-dev-loop.md) — a verified, run-it-yourself
+  guide for iterating on the embeddable canvas locally.
 - [`docs/adoption-paved-path.md`](docs/adoption-paved-path.md) — a holistic
   adoption roadmap for making kbx integration into another repository a guided,
   diagnosable path.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ flowchart LR
 - [Layer 3 — Engine](#layer-3--engine)
 - [Layer 4 — Representation](#layer-4--representation)
 - [Cross-cutting — identity & relations](#cross-cutting--identity--relations)
+- [The do-seam — affordances as a protocol-neutral action layer](#the-do-seam--affordances-as-a-protocol-neutral-action-layer)
 - [Extension points](#extension-points)
 - [Where things live](#where-things-live)
 
@@ -50,6 +51,12 @@ flowchart LR
 > [journeys](journeys.md) · [user-story demand map](user-stories.md) ·
 > [roadmap & program](roadmap.md). This document covers *how kbx is built*; those cover
 > *who it is for and what gets built next*.
+>
+> **See also — the surfaces, history, and open questions:**
+> [the two surfaces](surfaces.md) covers the SPA showcase vs the embeddable
+> Copilot canvas in depth; [history](history.md) is a verified, chronological
+> account of how kbx got here; [decisions](decisions/) records design choices
+> (made and still-open) worth preserving.
 
 ## The one-way dependency rule
 
@@ -348,13 +355,22 @@ interface Representation<Out = string> {
 
 A [`RepresentationRegistry`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/registry.ts)
 maps a target name to its implementation (parallel to the provider registry).
-`createDefaultRegistry()` pre-populates the three interchangeable built-ins:
+`createDefaultRegistry()`
+([`targets/index.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/index.ts))
+pre-populates four interchangeable built-ins:
 
 | Target | File | Output |
 |---|---|---|
 | `spa` | [`targets/spa.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/spa.tsx) | the interactive explorer website (React route tree) — see the **[live showcase](https://anokye-labs.github.io/kbexplorer/)** |
 | `json-ld` | [`targets/json-ld.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/json-ld.ts) | deterministic, canonicalized JSON-LD `@graph` |
 | `llm-context` | [`targets/llm-context.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/llm-context.ts) | **neighbour-anchored**, token-budgeted Markdown pack |
+| `copilot` | [`targets/copilot.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/copilot.tsx) | the embeddable, agent-driven Copilot canvas surface — see [surfaces](surfaces.md) |
+
+`copilot` is the newest target (registered by
+[template#442](https://github.com/anokye-labs/kbexplorer-template/pull/442),
+shipped in template `v0.4.0`). It proves the thesis of this whole layer: a
+**fourth** way to render the identical pure `KBGraph`, added with zero change to
+core, the engine, or the other three targets.
 
 ### `json-ld` — deterministic linked data
 
@@ -419,6 +435,50 @@ across providers and layers:
   by `mapRelation` (unknown phrasings fall back to `structural`). It is the
   shared normalization target so the same prose resolves to the same relation in
   the CLI's JSON-LD and the SPA's graph alike.
+
+---
+
+## The do-seam — affordances as a protocol-neutral action layer
+
+Everything above is about **reading** the graph. kbx also has a **write/act**
+seam — the **DO-seam** — for the agent-driven surfaces (the CLI, the Copilot
+canvas). It is a separate, later-arriving layer on top of the four
+representation layers, not a fifth core layer: it lives entirely in
+[`kbexplorer-cli`](https://github.com/anokye-labs/kbexplorer-cli), delivered by
+[kbexplorer#21 "Epic: Affordance action layer (the DO-seam), job layer and
+consent"](https://github.com/anokye-labs/kbexplorer/issues/21) (closed).
+
+### One choke point, many delivery adapters
+
+An **affordance** is a typed action — "given this context, what can I do, with
+what inputs/outputs?" — implemented once, behind one function:
+[`executeAffordance()`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/affordances/index.js).
+It knows nothing about MCP, JSON-RPC, HTTP, or canvases. Consent is enforced
+**inside** that one function
+([`src/affordances/consent.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/affordances/consent.js))
+— **fail-closed**: an affordance that requires consent and doesn't have it
+raises `CONSENT_REQUIRED`/`CONSENT_DENIED` rather than proceeding, regardless of
+which adapter called it.
+
+Three interchangeable adapters call the same choke point — none of them
+re-implement or bypass consent:
+
+| Adapter | Where | Notes |
+|---|---|---|
+| **Extension-tool adapter** (primary) | [`src/extension/tools.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/extension/tools.js) | Registers affordances as built-in `tools` in the **same** `joinSession({ canvases, tools })` call that ships the canvas — in-process, no MCP config exists or is consulted on this path. |
+| **MCP adapter** (optional) | [`src/mcp/server.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/mcp/server.js), [`src/mcp/tools.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/mcp/tools.js) | The same affordances exposed as an MCP server for non-canvas hosts (plain `copilot -p`, other agents/clients). MCP config only matters here. |
+| **Canvas do-seam adapter** | [`src/extension/canvas-server.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/extension/canvas-server.js) `POST /affordance/:name` | The loopback HTTP route the embeddable canvas calls for its `anchor`/`expand`/`trace`/`filter` actions ([template#194 / A5](https://github.com/anokye-labs/kbexplorer-cli/issues/194)). Routes straight through `executeAffordance` — same fail-closed gate, third surface after extension-tools and MCP. |
+
+The dependency arrow is **`affordances → {extension-tool adapter, MCP adapter,
+canvas adapter}`** — never the other direction, and never affordances coupled
+to any one protocol. A **job layer**
+([`kbexplorer-cli#154`](https://github.com/anokye-labs/kbexplorer-cli/issues/154))
+sits alongside the contract for long-running work (generation, indexing) that a
+single stateless call can't express — progress, cancellation, and
+review/approval are job-layer concerns, not adapter concerns.
+
+See [surfaces.md](surfaces.md) for how the canvas adapter fits into the
+loopback contract end to end.
 
 ---
 

--- a/docs/canvas-dev-loop.md
+++ b/docs/canvas-dev-loop.md
@@ -1,0 +1,173 @@
+# Run it yourself — the canvas dev loop
+
+This is a **verified** workflow: every command below was actually run against
+fresh clones of `kbexplorer-template` and `kbexplorer-cli` while writing this
+document, and the resulting canvas panel was opened and its served HTML
+inspected to confirm it was the real local build (not a fallback page). If a
+future CLI/template change breaks a step, please update this doc rather than
+leaving it stale.
+
+Use this loop to iterate on the embeddable Copilot canvas
+([surfaces.md](surfaces.md#surface-2--the-embeddable-copilot-canvas)) without
+publishing a template release or reinstalling the CLI.
+
+## Prerequisites
+
+- Node.js (tested with v26.3.0) and npm.
+- A local clone of [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template).
+- A local clone of [`kbexplorer-cli`](https://github.com/anokye-labs/kbexplorer-cli)
+  (only needed if you want to exercise the CLI's real loopback server rather
+  than a toy server — see step 3).
+- A repo to serve as KB host content. Any repo with a `content/` directory
+  works; this walkthrough uses a checkout of this repo (`kbexplorer`) as the
+  host, the same way `.github/workflows/showcase.yml` does.
+
+## 1 — Install and build the template in local mode
+
+```powershell
+cd path\to\kbexplorer-template
+npm ci
+```
+
+Generate a manifest in **local mode**, pointed at your host repo's content
+(`VITE_KB_HOST_ROOT`) — this is the same pair of env vars
+`.github/workflows/showcase.yml` sets for the GitHub Pages showcase build:
+
+```powershell
+$env:VITE_KB_LOCAL = 'true'
+$env:VITE_KB_HOST_ROOT = 'path\to\kbexplorer'   # or any repo with content/
+node scripts/generate-manifest.js
+```
+
+Then build:
+
+```powershell
+npx vite build
+```
+
+Confirm both entry points were emitted — `index.html` (the SPA showcase) and
+`canvas.html` (the embeddable canvas) — in `dist/`:
+
+```powershell
+Get-ChildItem dist\*.html
+# index.html
+# canvas.html
+```
+
+If only `index.html` appears, your template checkout predates
+[template#441](https://github.com/anokye-labs/kbexplorer-template/pull/441)
+(the additive `canvas.html` entry) — pull a newer `main` or a `v0.4.0`+ tag.
+
+## 2 — Install the CLI's dependencies
+
+The canvas is served by `kbexplorer-cli`'s loopback server, so its
+dependencies need to be installed too (frontmatter parsing, etc.), even though
+you won't run `kbx` as a CLI in this workflow:
+
+```powershell
+cd path\to\kbexplorer-cli
+npm ci
+```
+
+## 3 — Wire a session-scoped Copilot CLI extension
+
+Extensions live at `.github/extensions/<name>/extension.mjs` (project-scoped)
+or under the user/session extensions directory. For iteration, a
+**session-scoped** extension is convenient — it's discarded when the session
+ends and doesn't touch the repo. Scaffold one, then replace its body with a
+thin wrapper around the CLI's real `buildCanvasOptions()` — reusing the exact
+loopback server code the shipped extension uses, rather than hand-rolling a
+toy HTTP server:
+
+```js
+// extension.mjs
+import { joinSession, createCanvas } from "@github/copilot-sdk/extension";
+import { pathToFileURL } from "node:url";
+
+// Windows ESM requires a file:// URL for absolute paths — a bare drive-letter
+// path ("C:/...") is rejected by the default loader.
+const CLI_CANVAS_JS = pathToFileURL(
+  "C:/path/to/kbexplorer-cli/src/extension/canvas.js",
+).href;
+const { buildCanvasOptions } = await import(CLI_CANVAS_JS);
+
+// Tells canvas-server.js's defaultResolveBuildDir() which dist/ to serve
+// (must contain canvas.html or index.html). Set before buildCanvasOptions()
+// runs so the registry's resolution picks it up on open().
+process.env.KBX_CANVAS_BUILD_DIR = "C:/path/to/kbexplorer-template/dist";
+
+const session = await joinSession({
+  canvases: [createCanvas(buildCanvasOptions())],
+});
+```
+
+Reload extensions, then open the canvas (`kbexplorer` is the CLI's fixed
+canvas id — see `KBX_CANVAS_ID` in `src/extension/canvas.js`):
+
+```
+open_canvas(canvasId: "kbexplorer", instanceId: "<any-handle>")
+```
+
+This should return a `url` like `http://127.0.0.1:<ephemeral-port>`. Verify the
+real build is being served (not the built-in fallback placeholder) by
+fetching it and checking for the injected boot config:
+
+```powershell
+Invoke-WebRequest -Uri "http://127.0.0.1:<port>" -UseBasicParsing |
+  Select-Object -ExpandProperty Content |
+  Select-String -Pattern "__KBX_CANVAS__"
+```
+
+You should see something like:
+
+```html
+<script>window.__KBX_CANVAS__={"local":true,"visualMode":"inherit-host","searchServiceUrl":"http://127.0.0.1:<port>/search"};</script>
+```
+
+If instead you see `data-kbx-fallback="true"`, `KBX_CANVAS_BUILD_DIR` isn't
+pointing at a directory containing `canvas.html`/`index.html` — re-check the
+path and that step 1's build actually succeeded.
+
+## 4 — Iterate: rebuild, refresh
+
+`canvas-server.js` resolves the build directory **once**, the first time a
+given canvas `instanceId` is opened, but reads each file fresh
+(`readFileSync`) on every request. That means:
+
+- **Changing template source and rebuilding** (`npx vite build` again) is
+  picked up on the **next page load** of an already-open panel — no need to
+  close and reopen the canvas, just reload it.
+- **Switching which entry file exists** (e.g. a build that stops emitting
+  `canvas.html`) is *not* picked up without closing and reopening the canvas
+  (a new `open()` call re-resolves the build dir).
+
+A typical loop:
+
+```powershell
+# 1. edit kbexplorer-template source
+# 2. rebuild
+cd path\to\kbexplorer-template
+npx vite build
+# 3. reload the already-open canvas panel in the Copilot app
+```
+
+## 5 — Clean up
+
+Session-scoped extensions are discarded automatically when the session ends.
+To stop early, remove the extension's `.mjs` file and reload extensions; the
+loopback server for any open canvas instance is torn down when the canvas is
+closed (`onClose`).
+
+## What this does *not* cover
+
+This loop serves a **static** local build — it does not exercise:
+- the do-seam's `/affordance/:name` route beyond what `buildCanvasOptions()`
+  wires by default (no `actions` are declared in the snippet above — see
+  [architecture.md](architecture.md#the-do-seam--affordances-as-a-protocol-neutral-action-layer)
+  for the extension-tool adapter, which is a separate wiring concern from the
+  canvas declaration itself);
+- a real host repo's `dist/kb` build path (`<cwd>/dist/kb`, the third
+  resolution fallback in `defaultResolveBuildDir`) — this walkthrough always
+  used the explicit `KBX_CANVAS_BUILD_DIR` override;
+- hot module reloading — this is a production `vite build`, not `vite dev`;
+  each iteration is a full rebuild.

--- a/docs/decisions/conflation-correction.md
+++ b/docs/decisions/conflation-correction.md
@@ -1,0 +1,105 @@
+# Decision: connect sources, don't merge them
+
+**Status: decided and shipped.** Grounded in
+[`kbexplorer#15`](https://github.com/anokye-labs/kbexplorer/issues/15) (closed),
+[`kbexplorer#86`](https://github.com/anokye-labs/kbexplorer/issues/86), and the
+"Equivalence" section of
+[`kbexplorer#12`](https://github.com/anokye-labs/kbexplorer/issues/12). No
+single ADR document states this in one place across the org's history — this
+page consolidates the decision from that issue cluster, quoting rather than
+paraphrasing wherever it matters.
+
+## The naive approach this rejects
+
+The obvious way to federate "many sources → one graph" is fuzzy matching:
+compare names, addresses, titles across sources, compute a confidence score,
+and auto-merge above a threshold. kbx explicitly does not do this. From
+`kbexplorer#15`:
+
+> Connect — **not merge** — artifacts across sources... Three operations, no
+> confidence-threshold auto-merge.
+
+There is a real cost to rejecting the convenient version: no single pass
+"solves" federation. But confidence-threshold auto-merge is exactly the kind
+of silent, irreversible decision the rest of this system design tries to
+avoid (see the [do-seam](../architecture.md#the-do-seam--affordances-as-a-protocol-neutral-action-layer)'s
+fail-closed consent model, and `kbexplorer#12`'s "propose, don't overwrite"
+principle) — it would let two sources' records collapse into one node with no
+review step and no way back.
+
+## What ships instead — three narrow, deterministic operations
+
+`kbexplorer#15` scopes cross-source connection to exactly three operations,
+each delivered as its own `kbexplorer-cli` feature (all closed, all merged —
+see [history.md](../history.md#cross-source-connection--connect-not-merge)):
+
+1. **Reference edge-minting between distinct artifacts**
+   ([`cli#137`](https://github.com/anokye-labs/kbexplorer-cli/issues/137)) —
+   the high-value case: a doc *describes* an epic, a PR *implements* a work
+   item. The two artifacts stay two nodes; a typed edge connects them.
+2. **Referent conflation of shared people/teams/services**
+   ([`cli#138`](https://github.com/anokye-labs/kbexplorer-cli/issues/138)) —
+   generalizes the existing `person.linked` mechanism: one node with multiple
+   source-pointers, for the narrow case where the *same real-world entity* is
+   genuinely named in more than one source (a person in a directory and in a
+   calendar feed, say) — not a general similarity merge.
+3. **SoR-precedence resolution for conflicting facts**
+   ([`cli#139`](https://github.com/anokye-labs/kbexplorer-cli/issues/139)) —
+   for the rare case where two sources disagree about the same fact, a
+   **declared** precedence order wins, deterministically. No heuristic
+   arbitration.
+
+A fourth feature,
+[`cli#140`](https://github.com/anokye-labs/kbexplorer-cli/issues/140),
+requires the results to be **committed, deterministic git artifacts**
+(`.kbx/connection/conflation-map.json`, `minted-edges.json`,
+`manual-overrides.yaml`) with `kbx connect --check` parity in CI — so
+conflation state is reviewable, diffable, and never silently regenerated
+differently on two machines. Per `kbexplorer#15`:
+
+> LLM suggestions land **only** as committed overrides/rules a human reviews.
+
+## The corollary: there is no single canonical source
+
+This design has a direct consequence worth stating explicitly: **kbx does not
+assume, and does not need, one authoritative system of record.** Multiple
+sources can describe overlapping reality; the graph's job is to connect their
+witnesses (edges + conflation), not to pick a winner and discard the rest —
+except in the narrow, declared-precedence case of a genuinely conflicting
+fact. This matches `kbexplorer#12`'s framing of the underlying use case:
+
+> The adopter is standing up an organizational knowledge graph... assembled by
+> indexing the organization's authoritative source**s** [plural], never by
+> rewriting them. The rule is "Index, don't migrate."
+
+And the headline journey this whole epic serves,
+[`kbexplorer#86`](https://github.com/anokye-labs/kbexplorer/issues/86)
+("Morgan - multi-source unify"):
+
+> many sources -> one graph by **connection, not merge** - mint reference
+> edges between distinct artifacts, conflate shared people/teams/services,
+> declare SoR precedence for rare conflicts.
+
+## Where this sits in the sequencing — the adopter-driven re-center
+
+`kbexplorer#13` (the foundation program epic) deliberately defers this work
+rather than starting with it, even though "many sources → one graph" is the
+program's headline. Its "Wave 0" scopes to **identity (E1) + rich-Markdown
+rendering (E6) only**, stating explicitly that "none of it needs
+GitHub/ADO API machinery," and lists cross-source connection (E3), decoupling
+GitHub-the-host (E4), and access/governance labeling (E5) as **"Deferred epic
+stubs (map only; children later)."** The execution plan
+([`kbexplorer#90`](https://github.com/anokye-labs/kbexplorer/issues/90))
+confirms the same order: "Wave 0a" is the core release gate, "Wave 0b" is the
+rich-Markdown first-visible slice, and only later waves reach E3/E4/E5.
+
+In other words: the adoption-facing, single-source-of-truth-per-doc slice
+(stable identity + a document you can actually read) was sequenced ahead of
+the harder, more architecturally interesting multi-source-unification slice
+(this connect-not-merge design) — even though the latter is the more
+compelling long-term story. That re-centering is sequencing evidence in
+`kbexplorer#13`/`#90`, not a separately-written narrative document; it is
+recorded here because it explains *why* `kbexplorer#15` shipped when it did
+(after E1/E6, not before) rather than implying the connect-not-merge design
+itself was an afterthought. See [history.md](../history.md) for the dated
+account of when each wave actually shipped.

--- a/docs/decisions/markdown-rendering-default.md
+++ b/docs/decisions/markdown-rendering-default.md
@@ -1,0 +1,119 @@
+# Open question: should rich rendering be the default, not an opt-in?
+
+**Status: NOT DECIDED. NOT BUILT.** This page records a design tension raised
+during adoption planning. It is deliberately written as an open question with
+tradeoffs, not a decision — the granularity and identity questions below are
+genuinely unresolved. Do not treat anything here as a commitment.
+
+## The status quo being reconsidered
+
+Today, a Markdown document only gets kbx's richest rendering — frontmatter
+lifted into a structured facts panel, embedded `mermaid`/`dot`/`ics`/`canvas`
+blocks rendered live or via pre-built-SVG fallback — if it explicitly opts in
+with `display: rich-markdown` in its YAML frontmatter. The gate is a single,
+narrow discriminator function:
+
+```ts
+// kbexplorer-template/src/engine/providers/rich-markdown/detect.ts
+export function isRichAuthoredMarkdown(raw: string): boolean {
+  return readFrontmatterDisplay(raw) === 'rich-markdown';
+}
+```
+
+This was a deliberate choice, not an oversight — the same file's comment
+explains why: an explicit flag (rather than auto-detecting fenced blocks)
+"leaves existing authored docs that merely embed a Mermaid diagram... render
+via the plain prose path — completely untouched, with no change to their id,
+identity, or display." It protects existing content from an unannounced
+identity/rendering change. See [history.md](../history.md) for when this
+shipped ([`template#432`](https://github.com/anokye-labs/kbexplorer-template/pull/432)).
+
+## The tension
+
+The concern raised: **almost nobody hand-adds frontmatter to a bulk-imported
+Markdown repository.** If the goal is "index, don't migrate" — pull in an
+org's existing Markdown corpus as-is — an opt-in frontmatter gate means the
+richest rendering never fires on real, pre-existing content unless someone
+goes back and edits every file. That inverts the adoption story: the feature
+exists but the content that would benefit from it structurally cannot reach
+it without a migration step the whole design is trying to avoid.
+
+The suggested alternative direction has three parts, in increasing order of
+how unresolved they are.
+
+### (a) All markdown should render with the best available renderer by default
+
+Rather than requiring an explicit opt-in per document, the default should be:
+render every ingested Markdown document as richly as the available renderers
+allow, and let a document opt **down** to raw rendering only when it actually
+needs to (e.g. `display-mode: raw`) — inverting today's opt-in gate to an
+opt-out escape hatch.
+
+### (b) Display mode as a property of the source/provider, not the document
+
+Rather than a per-document frontmatter flag, the render/display mode could be
+a configuration property of the **Source** or **Provider** that ingested the
+document — meaning two byte-identical `.md` files could render differently
+depending on which provider brought them in (one repo's docs get rich
+rendering by provider config; another repo's byte-identical copy, ingested via
+a different provider, renders plain). This composes naturally with the
+existing `Source`/`Provider` seams described in
+[architecture.md](../architecture.md) — display mode would be exactly the
+kind of per-source configuration those seams are built to carry — but no
+prototype of this exists.
+
+### (c) Embedded blocks as first-class `kg://` graph nodes
+
+Today an embedded block (a fenced `mermaid`/`dot`/`ics`/`canvas` block inside a
+rich-Markdown doc) is a part of its parent document's node — it has no
+identity or edges of its own. The idea raised: some embedded blocks are
+substantial enough to deserve **promotion** to their own graph node, with
+their own `kg://` identity and edges back to the parent document. Worked
+example: a `squads.md` document's frontmatter becomes a `squad` node's
+structured data (as today), but an embedded block that references a linked
+resource — say, a team roster or an org-chart fragment — could become its
+own promotable node other parts of the graph can point at directly, rather
+than only being reachable by first navigating to the parent document.
+
+## Why this is not a decision yet
+
+Each part above raises a genuinely open question with real tradeoffs, not
+just an implementation detail:
+
+- **(a) breaks the explicit protection** the current gate was built for —
+  existing docs that merely embed a Mermaid diagram would change identity/
+  display without anyone asking for it, unless the opt-down default is
+  chosen very carefully (e.g. scoped only to *newly ingested* sources, not
+  retroactively to existing ones).
+- **(b) has no prototype.** It's a plausible extension of the existing
+  `Source`/`Provider` config surface, but nobody has built or tested a
+  provider-scoped display-mode config, and it isn't clear yet whether
+  "display mode" belongs on the `Source` (which resource is retrieved) or the
+  `Provider` (how it's turned into nodes) — they are different seams
+  ([architecture.md](../architecture.md#layer-1--sources) vs
+  [Layer 2](../architecture.md#layer-2--providers)).
+- **(c) has two open, unresolved sub-questions of its own:**
+  - **Granularity** — which embedded blocks are worth promoting? Every fenced
+    block, or only ones that reference another resource? Promoting
+    everything risks graph noise; promoting selectively requires a rule
+    nobody has written yet.
+  - **Identity scheme for promoted blocks** — a deterministic
+    `kg://parent#block-index` (stable as long as block order doesn't change,
+    but liable to drift if blocks are reordered or inserted) versus a
+    content-hash-based identity (stable under reordering, but changes if the
+    block's content changes at all, which may or may not be desirable
+    depending on whether you want the promoted node to track its source
+    block's edits). Neither has been chosen; both have precedent elsewhere
+    in the system — `kg://` identity is content-independent by design
+    ([architecture.md](../architecture.md#cross-cutting--identity--relations)),
+    while the rich-Markdown block registry already computes a `contentHash`
+    per block for change detection, so a hash-based option would reuse
+    existing plumbing rather than invent new plumbing.
+
+## What would need to happen before this becomes a decision
+
+At minimum: a prototype of provider-scoped display-mode config against a
+second real Source/Provider (to test whether the seam actually wants this
+property), and a concrete proposal — with tradeoffs written down, not just
+asserted — for the block-promotion granularity rule and identity scheme. Until
+then, this stays exactly what it is: a documented question, not a plan.

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,0 +1,188 @@
+# History — a verified, chronological account
+
+This is a dated changelog across all five repos in the kbx system
+(`kbexplorer-core`, `kbexplorer-cli`, `kbexplorer-template`,
+`kbexplorer-search`, and this docs/showcase repo, `kbexplorer`), built by
+reading actual PR/issue bodies and merge timestamps — not by summarizing prior
+notes. Where [roadmap.md](roadmap.md) shows the *structural* plan (epics and
+waves), this page shows the *order things actually shipped in*.
+
+Every entry below is sourced from a `gh pr view` / `gh issue view` /
+`git log` / `git tag` lookup against the live repos. Timestamps are merge
+times (`mergedAt`), not commit author dates, which can differ.
+
+> **Scope note.** This is not exhaustive — dozens of smaller PRs shipped
+> between the milestones below. It tracks the capability-defining moments the
+> rest of this doc set (architecture, surfaces, decisions) refers back to.
+
+## Foundation — `kbexplorer-core` contracts
+
+`kbexplorer-core` ships no application code — only the dependency-free
+contracts every other repo imports. It cut three tagged releases in quick
+succession:
+
+| Release | Tagged | Notable contracts added |
+|---|---|---|
+| [`v0.1.0`](https://github.com/anokye-labs/kbexplorer-core/releases/tag/v0.1.0) | 2026-06-30 07:52 -0400 | Configurable identity scheme/authority, opaque type-independent address body, alias-based person identity, presentation-token contract, canvas-as-Representation-target convention, SourceRef/provenance, observed-vs-derived. |
+| [`v0.2.0`](https://github.com/anokye-labs/kbexplorer-core/releases/tag/v0.2.0) | 2026-06-30 15:42 -0400 | Identity claims + `linkedRefs`, source-precedence config, `relationRaw` passthrough. |
+| [`v0.3.0`](https://github.com/anokye-labs/kbexplorer-core/releases/tag/v0.3.0) | 2026-06-30 17:00 -0400 | Access-label field on nodes/edges (E5). |
+
+A fourth contract — redaction + access-review — merged to `main` after `v0.3.0`
+but is **not yet tagged as a release** as of this writing.
+
+## The rich-Markdown slice — Mermaid, block rendering, and authored ingestion (three distinct capabilities)
+
+These three shipped on consecutive days, in this order, and are easy to
+conflate because they all touch "Markdown rendering." They are not the same
+change:
+
+1. **2026-06-29 19:02:57Z** — [`kbexplorer-template#422`](https://github.com/anokye-labs/kbexplorer-template/pull/422)
+   *"Render Mermaid diagrams in ReadingView"* (closes
+   [#417](https://github.com/anokye-labs/kbexplorer-template/issues/417)).
+   Representation-layer only: `ReadingView`'s `display: diagram` nodes and
+   fenced `mermaid` code blocks render live, with a visible raw-source
+   fallback for invalid/unsupported diagrams. This is the **first** live
+   diagram rendering in the reading view.
+2. **2026-06-30 12:56:57Z** — [`kbexplorer-template#430`](https://github.com/anokye-labs/kbexplorer-template/pull/430)
+   *"Rich-Markdown rendering with block-renderer registry"* (closes
+   [#427](https://github.com/anokye-labs/kbexplorer-template/issues/427)).
+   Adds an open block-renderer registry, a `RichMarkdownDocumentView`
+   (frontmatter facts + prose + blocks), reuses #422's inline Mermaid path as
+   the one *live* renderer, and adds a **pre-built-SVG fallback** for
+   `dot`/`ics`/`canvas` blocks so nothing falls back to raw code when an SVG
+   exists. At merge, this only fired on the `?demo=richmd` sample route — no
+   authored content used it yet.
+3. **2026-06-30 17:50:23Z** — [`kbexplorer-template#432`](https://github.com/anokye-labs/kbexplorer-template/pull/432)
+   *"Authored rich-Markdown integration"* (closes
+   [#431](https://github.com/anokye-labs/kbexplorer-template/issues/431)).
+   Wires the published
+   [`@anokye-labs/kbexplorer-provider-rich-markdown`](https://github.com/anokye-labs/kbexplorer-provider-rich-markdown)
+   package's `ingestRichMarkdown` (pinned `v0.1.0`) into the engine via a new
+   `AuthoredRichMarkdownProvider`. A doc opts in with `display: rich-markdown`
+   in its YAML frontmatter — the discriminator lives in
+   [`src/engine/providers/rich-markdown/detect.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/providers/rich-markdown/detect.ts).
+   This is the change that makes #430's rendering reachable from **real,
+   authored content** for the first time.
+
+`kbexplorer-template v0.3.0` tagged at **2026-06-30 18:10:17Z** carries both
+#430 and #432.
+
+### The showcase lights it up the same day
+
+[`kbexplorer#95`](https://github.com/anokye-labs/kbexplorer/pull/95) *"showcase:
+render this repo as the KB host with a rich-Markdown demo"* merged
+**2026-06-30 18:16:19Z** — six minutes after the template tag. It bumped this
+repo's `TEMPLATE_REF` from `v0.2.0` to `v0.3.0`, wired `VITE_KB_HOST_ROOT` to
+this repo, and added `content/org/platform.md` with `display: rich-markdown`
+in its frontmatter. **This file is still in the repo and still deployed** —
+the live showcase at
+[anokye-labs.github.io/kbexplorer](https://anokye-labs.github.io/kbexplorer/)
+has been rendering frontmatter-facts-as-structured-panel plus a live inline
+Mermaid diagram from real, authored content since that merge. This satisfies
+the acceptance criteria stated in
+[kbexplorer#13](https://github.com/anokye-labs/kbexplorer/issues/13)'s
+"Wave 0 done" section. **The rich-Markdown capability is shipped, released,
+and live — not dormant.**
+
+## The Copilot canvas epic
+
+Two epics frame this work: [`kbexplorer-template#401`](https://github.com/anokye-labs/kbexplorer-template/issues/401)
+("Copilot canvas representation target — host-themeable, embeddable",
+de-risking/shared infra, **closed**) and
+[`kbexplorer-template#407`](https://github.com/anokye-labs/kbexplorer-template/issues/407)
+("bespoke copilot Representation target — agent-driven, anchor-first", the
+destination surface, **still open** — 3 of 6 sub-issues shipped as of this
+writing).
+
+Three PRs landed in sequence on 2026-07-01, each unblocking the next:
+
+| Merged (UTC) | PR | Closes issue | What |
+|---|---|---|---|
+| 01:14:05 | [template#441](https://github.com/anokye-labs/kbexplorer-template/pull/441) | [#406](https://github.com/anokye-labs/kbexplorer-template/issues/406) | Embeddable headless canvas mount (`canvas.html`/`canvas.tsx`) + `inherit-host` visual mode. Renders through the existing `spa` Representation — nothing new rendered yet, just a new host. |
+| 01:44:18 | [template#442](https://github.com/anokye-labs/kbexplorer-template/pull/442) | [#440](https://github.com/anokye-labs/kbexplorer-template/issues/440) | Registers a distinct `copilot` Representation target. Initially delegates to the `spa` route tree — the seam, not yet the bespoke view. |
+| 02:20:08 | [template#443](https://github.com/anokye-labs/kbexplorer-template/pull/443) | [#408](https://github.com/anokye-labs/kbexplorer-template/issues/408) | Replaces the `copilot` target's `spa` delegation with the **anchor-first** landing — the first bespoke (non-reused) piece of the canvas UX. The constellation is no longer the default view for this target. |
+
+[`template#444`](https://github.com/anokye-labs/kbexplorer-template/pull/444)
+*"chore(release): 0.4.0"* merged **02:33:28Z**, cutting the first template
+release carrying the bespoke Copilot canvas surface. Per the CLI's
+`getLatestTag()` (a dynamic `git ls-remote --tags` lookup at install/update
+time — see
+[`kbexplorer-cli/src/lib/version.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/lib/version.js)),
+this is not a hardcoded pin: any `kbx init`/`kbx update` run after this tag
+picks up `v0.4.0` and the canvas surface automatically.
+
+**Still open in template#407** (not yet built, as of this writing): agent
+action surface (`anchor`/`expand`/`trace`/`filter` beyond the do-seam's raw
+HTTP contract), bidirectional click→chat, an affordance-aware node launchpad,
+and a fully conversation-shaped shell. See
+[surfaces.md](surfaces.md#why-the-distinction-matters).
+
+### The do-seam that the canvas calls into
+
+In parallel, `kbexplorer-cli` built the loopback server the canvas talks to:
+[`cli#199`](https://github.com/anokye-labs/kbexplorer-cli/pull/199) "A1:
+Loopback canvas server + real `open()`" (closes
+[#190](https://github.com/anokye-labs/kbexplorer-cli/issues/190)),
+[`cli#200`](https://github.com/anokye-labs/kbexplorer-cli/pull/200) (`/manifest`
++ `/search`), and [`cli#201`](https://github.com/anokye-labs/kbexplorer-cli/pull/201)
+(`/events` SSE + `/affordance/:name` do-seam). The affordance action contract
+itself — the protocol-neutral core these all route through — was delivered
+earlier by [`kbexplorer#21`](https://github.com/anokye-labs/kbexplorer/issues/21)
+("Epic: Affordance action layer (the DO-seam), job layer and consent",
+closed) via `kbexplorer-cli#153` (contract). See
+[architecture.md](architecture.md#the-do-seam--affordances-as-a-protocol-neutral-action-layer)
+for the adapter model this enables.
+
+## Cross-source connection — "connect, not merge"
+
+[`kbexplorer#15`](https://github.com/anokye-labs/kbexplorer/issues/15) ("Epic:
+Cross-source connection (edge-minting, referent conflation, SoR-precedence)",
+closed) shipped four `kbexplorer-cli` features, in this dependency order:
+reference edge-minting (`cli#137`), referent conflation (`cli#138`),
+SoR-precedence resolution (`cli#139`), and committed connection artifacts +
+`--check` parity (`cli#140`). See
+[decisions/conflation-correction.md](decisions/conflation-correction.md) for
+the design reasoning this epic encodes.
+
+## `kbexplorer-search`
+
+A standalone semantic-search companion module
+(`@anokye-labs/kbexplorer-search`), driven through the `kbx` CLI
+(`kbx search-index`, `kbx search`). Shipped its package skeleton and core
+search engine first, then graph-aware ranking, an optional FAISS-accelerated
+index with graceful fallback, a runnable serve service matching the template's
+search contract, and — most recently — access-label filtering so restricted or
+unknown-access content is excluded from the index (E5-A3).
+
+## Honest status, as of this writing
+
+**Merged, released, and verified live end-to-end:**
+- Mermaid rendering in `ReadingView` (template `v0.2.0`+).
+- Rich-Markdown block rendering + authored ingestion, live on the showcase via
+  `content/org/platform.md` (template `v0.3.0`+, this repo since
+  `kbexplorer#95`).
+- The `copilot` Representation target + embeddable canvas mount + anchor-first
+  home view (template `v0.4.0`).
+- The do-seam contract + extension-tool adapter + MCP adapter + canvas
+  `/affordance/:name` adapter (`kbexplorer-cli`, `kbexplorer#21` closed).
+- Cross-source connection primitives — edge-minting, referent conflation,
+  SoR-precedence (`kbexplorer#15` closed) — though these are not yet exercised
+  by any real multi-source (e.g. GitHub↔Azure DevOps) content in this repo's
+  showcase; they are merged and tested in `kbexplorer-cli`, not yet
+  demonstrated end-to-end here.
+
+**Merged but narrow — real code, small surface:**
+- The `copilot` target's anchor-first view is the *only* shipped piece of
+  `template#407`'s six-item bespoke-canvas epic. Agent actions, click→chat,
+  the node launchpad, and the conversation-shaped shell are designed
+  (see the epic body) but not built.
+- The canvas's `/events` SSE endpoint is live but its domain triggers
+  (file-watch → `graph-updated`, canvas action → `anchor`) are still a no-op
+  heartbeat-only seam — real triggers are an explicit follow-up.
+
+**Designed but not built:**
+- The forward-looking rendering-default question in
+  [decisions/markdown-rendering-default.md](decisions/markdown-rendering-default.md)
+  — whether display mode should be provider-scoped rather than a frontmatter
+  opt-in gate, and whether embedded blocks should become first-class `kg://`
+  nodes — is an open design question, not a decision, let alone shipped code.

--- a/docs/surfaces.md
+++ b/docs/surfaces.md
@@ -1,0 +1,146 @@
+# The two surfaces
+
+kbx renders one pure `KBGraph` ([architecture](architecture.md)) onto **two
+genuinely different surfaces**. They look superficially similar — both are a
+web UI showing the same graph — and that similarity is exactly what causes
+confusion. They are not two versions of the same product, one newer than the
+other. They are two different **Representation targets**
+([`spa`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/spa.tsx)
+and
+[`copilot`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/copilot.tsx)),
+built for different consumers, shipped by different mechanisms, and updated on
+different schedules. **One changing does not imply the other changed.**
+
+| | The SPA showcase | The embeddable Copilot canvas |
+|---|---|---|
+| **Consumer** | A human, full-viewport, browsing | An agent (Copilot), narrow side-panel, conversation-anchored |
+| **Entry point** | `index.html` | `canvas.html` |
+| **Representation target** | `spa` | `copilot` |
+| **Hosting** | Static site on GitHub Pages | Served by `kbexplorer-cli` over a `127.0.0.1` loopback HTTP server, one per canvas instance |
+| **Who opens it** | Anyone with the URL | An agent, via `open_canvas` / `invoke_canvas_action` inside the GitHub Copilot app |
+| **Default landing view** | The constellation (force-directed graph) | The **anchor-first** view — an anchor node + its weight-ranked neighbors; the constellation is an optional zoom-out |
+| **Navigation model** | Human drags/clicks the force graph | Agent steers via actions; a `kg://` chip re-anchors |
+| **Update cadence** | Rebuilt by `.github/workflows/showcase.yml` on push to `main`, on demand, or nightly | Rebuilt whenever the template is rebuilt locally / the CLI's pinned template release changes |
+
+## Surface 1 — the SPA showcase
+
+This is the human-facing, full-page single-page app: the constellation /
+overview / reading-view / HUD experience at
+**[anokye-labs.github.io/kbexplorer/](https://anokye-labs.github.io/kbexplorer/)**.
+
+It is built and deployed by
+[`.github/workflows/showcase.yml`](../.github/workflows/showcase.yml) in *this*
+repo: the workflow checks out `kbexplorer-template` pinned to a release tag
+(`TEMPLATE_REF`, currently `v0.4.0`), checks out *this* repo as the content
+host, bakes a manifest in **local mode**
+(`VITE_KB_LOCAL=true`, `VITE_KB_HOST_ROOT=<this checkout>`) so the deployed
+bundle needs no runtime GitHub token or API calls, builds `index.html` with
+`vite build`, and deploys the result to GitHub Pages. It runs on push to
+`main`, on `workflow_dispatch`, and on a daily schedule (the schedule exists
+partly to backstop bot merges, which use `GITHUB_TOKEN` and don't emit a `push`
+event).
+
+`TEMPLATE_REF` is a manually-bumped pin, not `main` — the template's own release
+notes advise host repos to pin to a tag. Bumping it is an ordinary,
+issue-first PR in this repo (see
+[kbexplorer#95](https://github.com/anokye-labs/kbexplorer/pull/95) and
+[kbexplorer#99](https://github.com/anokye-labs/kbexplorer/pull/99) for two real
+examples of that bump landing).
+
+## Surface 2 — the embeddable Copilot canvas
+
+This is the agent-facing surface: a panel a Copilot agent opens inside the
+GitHub Copilot app via `open_canvas`, backed by `canvas.html` — an
+**additive**, headless entry point the template build emits alongside
+`index.html` (`vite.config.ts`'s `rollupOptions.input` lists both). The full
+`index.html`/`main.tsx` path is untouched by anything below.
+
+### Who serves it
+
+`kbexplorer-cli` — not GitHub Pages, not any static host. The CLI's extension
+declares a canvas
+([`src/extension/canvas.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/extension/canvas.js)
+`buildCanvasOptions()`), and when an agent opens it, the CLI starts (or
+rehydrates) **one loopback HTTP server per canvas `instanceId`**
+([`src/extension/canvas-server.js`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/src/extension/canvas-server.js)),
+bound to `127.0.0.1:0` (an OS-assigned ephemeral port — never a routable
+interface). That server serves whichever build directory it resolves
+(`KBX_CANVAS_BUILD_DIR` override, else `<template>/dist`, else `<host>/dist/kb`)
+and injects a boot-config script before the bundle executes:
+
+```js
+window.__KBX_CANVAS__ = {
+  local: true,
+  visualMode: 'inherit-host',
+  searchServiceUrl: '<origin>/search',
+  anchorNodeId, // optional — the node to focus on open
+};
+```
+
+This loopback boundary is documented and frozen in the CLI's
+[`docs/canvas-loopback-contract.md`](https://github.com/anokye-labs/kbexplorer-cli/blob/main/docs/canvas-loopback-contract.md):
+`GET /` (the entry + boot config), `GET /manifest` + `/manifest/slice` (graph
+data), `POST /search`, `GET /events` (SSE — `graph-updated` / `anchor`), and
+`POST /affordance/:name` (the do-seam adapter — see
+[architecture.md](architecture.md#the-do-seam--affordances-as-a-protocol-neutral-action-layer)).
+**The CLI never renders; the template never touches disk or spawns servers** —
+the only thing crossing the line is HTTP on that per-instance loopback origin.
+
+### What it renders
+
+`canvas.html` boots a headless shell
+([`src/canvas/EmbeddableApp.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/canvas/EmbeddableApp.tsx) —
+`FluentProvider` + `HashRouter` only, no HUD/favicon/dock padding) that resolves
+the `copilot` Representation target
+([`src/representation/targets/copilot.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/copilot.tsx)).
+That target's default landing is **not** the constellation — it's the
+**anchor-first view**
+([`AnchorFirstView.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/targets/copilot-home/AnchorFirstView.tsx)):
+the anchor node rendered through its normal node-type viewer, its
+weight-ranked neighbors expanded inline up to `DEFAULT_MAX_EXPANDED` (6), and
+every neighbor beyond that as a navigable `kg://` chip. Clicking a chip
+re-anchors (`/node/:id`); the constellation is reachable as an explicit
+zoom-out, not the landing.
+
+### Theming
+
+The canvas inherits the host's visual identity rather than shipping its own:
+`useCanvasTheme` resolves Fluent design tokens from CSS variables the host
+mirrors onto the iframe's `<html>` element, with a `MutationObserver` that
+re-resolves on host theme switches, falling back to the template's own
+configured theme when nothing is mirrored.
+
+## Why the distinction matters
+
+The two surfaces share almost everything **except** the one thing people
+assume they share: what gets rendered right now. Both reuse the same pure
+`KBGraph`, the same `kg://` identity scheme, the same six-member relation
+taxonomy, and — as of the `copilot` target's initial cut — the same node-type
+viewers as the `spa` target. But:
+
+- **They deploy independently.** The SPA showcase redeploys when *this* repo's
+  `TEMPLATE_REF` is bumped or its content changes. The canvas redeploys
+  whenever whoever installed the CLI updates their pinned template build. A
+  change to one is invisible on the other until someone explicitly re-pins.
+- **They default to different views on purpose.** The SPA's constellation is
+  built for a human with a mouse and a full viewport to *explore*. The
+  canvas's anchor-first view is built for a conversation where the agent
+  already knows what it's talking about and the panel should confirm, not
+  make the human search for it.
+- **The canvas is not "the SPA in an iframe."** It is a distinct
+  `Representation` target (`copilot`, registered by
+  [template#442](https://github.com/anokye-labs/kbexplorer-template/pull/442))
+  that currently reuses the `spa` target's node viewers, but is free to diverge
+  — and already has, via the anchor-first landing
+  ([template#443](https://github.com/anokye-labs/kbexplorer-template/pull/443)).
+- **The canvas epic is still open.** Only the anchor-first home view has
+  shipped so far out of [template#407](https://github.com/anokye-labs/kbexplorer-template/issues/407)'s
+  six sub-issues — agent actions (anchor/expand/trace/filter beyond the
+  do-seam's HTTP contract), bidirectional click→chat, an affordance-aware
+  node launchpad, and a fully conversation-shaped shell are designed but not
+  yet built. See [history.md](history.md) for the verified, dated account.
+
+## Run it yourself
+
+To build and serve the canvas locally against your own template build, see
+[canvas-dev-loop.md](canvas-dev-loop.md).


### PR DESCRIPTION
Closes #100.

Substantially expands this repo's documentation, grounded in verified `gh pr view` / `gh issue view` / `git log` / `git tag` forensics across all five kbx repos (`kbexplorer-core`, `kbexplorer-cli`, `kbexplorer-template`, `kbexplorer-search`, `kbexplorer`) — not summarized from prior notes.

## What changed

- **`docs/architecture.md`** — new section on the **do-seam**: one `executeAffordance` choke point, three interchangeable delivery adapters (extension-tool primary, MCP optional, canvas), consent enforced once at the core, fail-closed. Registers `copilot` as a fourth concrete Representation target alongside `spa`/`json-ld`/`llm-context` (shipped in template `v0.4.0`, [template#442](https://github.com/anokye-labs/kbexplorer-template/pull/442)).
- **`docs/surfaces.md`** (new) — makes explicit that the SPA showcase (GitHub Pages, `index.html`, human-driven) and the embeddable Copilot canvas (`canvas.html`, served by `kbexplorer-cli` over a loopback server, agent-driven, anchor-first) are **different Representation targets over the same graph**, not two versions of one product — deployed independently, on different schedules.
- **`docs/history.md`** (new) — a verified, dated changelog. Notably corrects the historical record: Mermaid rendering ([template#422](https://github.com/anokye-labs/kbexplorer-template/pull/422), merged 2026-06-29), the rich-Markdown block-renderer registry ([template#430](https://github.com/anokye-labs/kbexplorer-template/pull/430)), and authored rich-Markdown ingestion ([template#432](https://github.com/anokye-labs/kbexplorer-template/pull/432)) are three distinct, correctly-ordered capabilities — and the rich-Markdown demo (`content/org/platform.md`) is confirmed **live on this repo's own showcase since [#95](https://github.com/anokye-labs/kbexplorer/pull/95)**, not dormant. Includes an honest shipped / merged-but-narrow / designed-only status section.
- **`docs/decisions/conflation-correction.md`** (new) — cross-source data connects via reference-edge minting + narrow referent conflation + declared SoR precedence, never fuzzy-match auto-merge (decided and shipped, [kbexplorer#15](https://github.com/anokye-labs/kbexplorer/issues/15)), plus the adopter-driven sequencing that deferred it behind identity + rich-Markdown foundations ([kbexplorer#13](https://github.com/anokye-labs/kbexplorer/issues/13)).
- **`docs/decisions/markdown-rendering-default.md`** (new) — an explicitly **open, not decided** design question: should rich rendering default-on per source/provider instead of requiring a per-document frontmatter opt-in? References the current gate at `kbexplorer-template/src/engine/providers/rich-markdown/detect.ts`. Written with tradeoffs, not as a plan.
- **`docs/canvas-dev-loop.md`** (new) — a run-it-yourself guide, **actually verified**: built `kbexplorer-template` locally in local mode, installed `kbexplorer-cli`'s dependencies, wired a session-scoped Copilot CLI extension around the CLI's real `buildCanvasOptions()`, opened the resulting canvas panel, and confirmed the served HTML was the real local build (injected `window.__KBX_CANVAS__`, not the fallback placeholder) before writing any of it up.
- **`README.md`** — links the new docs and lists `kbexplorer-search` / `kbexplorer-provider-rich-markdown` among the related repos.

## Verification

- All PR/issue numbers, merge timestamps, and file paths cited were checked against the live repos (cloned `kbexplorer-core`, `kbexplorer-cli`, `kbexplorer-template`, `kbexplorer-search`, `kbexplorer-provider-rich-markdown`) rather than assumed.
- The dev-loop guide's steps were literally executed in this session (manifest generation, `vite build`, extension wiring, canvas open, HTTP fetch of the served panel).
- No new app code — this repo remains docs/showcase-only per `AGENTS.md`.