### PR TITLE
docs: document search, link core contracts, honest AGENTS.md (#102 wave)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,8 +72,8 @@ is working the repo:
   file, re-run the check, re-fetch the live resource — not the state at the
   time the PR was opened. Then close it citing the specific evidence (a file
   and line, a check-run URL, a fetched page) that satisfied each criterion.
-- **Conventional Commits.** `type(scope): description`, per the commit
-  conventions at the top of this document.
+- **Conventional Commits.** `type(scope): description` — types: `feat`, `fix`,
+  `docs`, `style`, `refactor`, `test`, `chore`, `ci`.
 - **Workback scheduling / work breakdown.** When a program is large enough to
   need a real Epic → Feature → Task breakdown — native GitHub sub-issues plus
   `blocked-by` dependency edges sequenced into waves — don't hand-roll it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,16 +17,25 @@ re-describing types — the contract is the source of truth.
 
 ## Branch Protection
 
-The default branch is protected:
+**Check, don't assume.** A live audit (#105) found this repo has **no branch
+protection ruleset on `main` at all**, despite this section previously
+claiming required status checks and conversation resolution were enforced —
+that claim was false. Do not rely on any protection invariant (required
+checks, conversation resolution, force-push/deletion blocks) without
+verifying it directly against the live repo first — e.g.
+`gh api repos/anokye-labs/kbexplorer/rules/branches/main` (or the equivalent
+REST/GraphQL/MCP call) — rather than trusting what this document says the
+ruleset is.
 
-- **Pull request required** — no direct pushes to `main`.
-- **Required status checks** (strict / up-to-date) — `pr-title`,
-  `check-linked-issue`, `dependency-review`.
-- **Conversation resolution required** before merge.
-- **0 approvals required** — agent PRs auto-merge once green via the `auto-merge`
-  workflow. Force pushes and branch deletion are blocked.
+Regardless of what the live ruleset does or doesn't enforce, these rules are
+non-negotiable for every contributor, human or agent:
 
-Never commit directly to `main`. Never force push.
+- **Never commit directly to `main`.**
+- **Never force push** — to `main` or to any shared branch.
+
+If you find the live ruleset doesn't match what's documented (or is missing
+entirely), don't quietly work around the gap: it's a finding, not a
+convenience. File or update an issue (see #105 for the tracked example).
 
 ## Issue-First Workflow
 
@@ -34,12 +43,45 @@ Never commit directly to `main`. Never force push.
 
 1. Create an Issue (with a native Issue **Type**: Epic / Feature / Task / Bug).
 2. Create a branch and implement.
-3. Open a PR that references the issue (e.g. `Closes #12`).
-4. CI goes green → the PR auto-merges (0 approvals), which closes the issue.
+3. Open a PR that references the issue with `refs #N` — never `Closes #N` /
+   `Fixes #N`. Closure is a deliberate, separate step (see
+   [GitHub & Work-Item Conventions](#github--work-item-conventions)), not an
+   automatic side effect of a merge.
+4. CI goes green → the PR auto-merges (0 approvals). Once merged, re-verify
+   the referenced issue's acceptance criteria against the now-current repo
+   state, then close it citing that evidence.
 
 Use the **GraphQL API** for issue types, sub-issues, and blocked-by relationships
 (the REST API does not support them). Include `GraphQL-Features: sub_issues` for
 sub-issue operations.
+
+## GitHub & Work-Item Conventions
+
+These conventions are tool-agnostic and apply no matter which agent or human
+is working the repo:
+
+- **Tool-agnostic GitHub interaction.** Use whichever interface is available
+  and fits the task — the `gh` CLI, the REST API, the GraphQL API, or an MCP
+  GitHub server. None is mandated. The one hard requirement is **GraphQL
+  capability** for anything touching issue sub-issues or `blocked-by`
+  dependency edges — the REST API does not expose either.
+- **`refs #N`, never `closes #N`.** See Issue-First Workflow above — closure
+  is deliberate, not automatic.
+- **Verification before close.** Before closing any issue, re-verify its
+  acceptance criteria against the **current** state of the repo — re-read the
+  file, re-run the check, re-fetch the live resource — not the state at the
+  time the PR was opened. Then close it citing the specific evidence (a file
+  and line, a check-run URL, a fetched page) that satisfied each criterion.
+- **Conventional Commits.** `type(scope): description`, per the commit
+  conventions at the top of this document.
+- **Workback scheduling / work breakdown.** When a program is large enough to
+  need a real Epic → Feature → Task breakdown — native GitHub sub-issues plus
+  `blocked-by` dependency edges sequenced into waves — don't hand-roll it.
+  Use
+  [`kbexplorer-template`'s `wbs-builder` skill](https://github.com/anokye-labs/kbexplorer-template/blob/main/.agents/skills/wbs-builder/SKILL.md),
+  which materializes native issue types, parent/child sub-issues, and
+  dependency edges via the GraphQL API and sequences work in dependency-order
+  waves.
 
 ## Verification
 

--- a/README.md
+++ b/README.md
@@ -71,4 +71,11 @@ satisfies it, or start from an epic and find who it is for. The work is tracked 
 built in self-contained local mode over a sample knowledge base and published to
 GitHub Pages from this repo.
 
+The deployed showcase is static (self-contained local mode, no backend), so it
+doesn't run a search service by default. To try semantic search over this
+repo's own content: `kbx search-index` to build `.search/` artifacts, then
+`kbx search-serve` (or `npx @anokye-labs/kbexplorer-search serve`) and point a
+local template dev build's `VITE_SEARCH_SERVICE_URL` at it — see
+[Search in `docs/architecture.md`](docs/architecture.md#search--a-first-class-representation-over-the-graph).
+
 > See [`docs/architecture.md`](docs/architecture.md) for the system overview.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,17 +128,12 @@ fully writable worktrees through the *same* interface.
 #### Resources are self-describing and navigable
 
 A [`Resource`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
-carries everything a consumer needs without a second round-trip:
-
-```ts
-interface Resource<T = unknown> {
-  href: string;            // stable locator for re-retrieval
-  kind: string;            // open: 'file' | 'tree' | 'commit' | 'issue' | …
-  affordances: Affordance[]; // what's allowed on THIS retrieval (situational)
-  links: ResourceLink[];   // hypermedia: { rel, href, type?, title? }
-  body: T;                 // payload; shape depends on kind
-}
-```
+carries everything a consumer needs without a second round-trip: a stable
+`href` locator for re-retrieval, an open `kind` string, the `affordances`
+allowed on *this* retrieval (situational, see below), hypermedia `links`, and
+a `body` payload whose shape depends on `kind`. See the
+[`Resource` interface](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+for the exact field types.
 
 #### Affordances are advertised **per retrieval**, never per type or per instance
 
@@ -221,17 +216,12 @@ Contract tests live in
 A **`GraphProvider`**
 ([`provider.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/provider.ts))
 turns resources (and the graph fragments earlier providers produced) into a pure
-graph fragment of nodes + edges:
-
-```ts
-interface GraphProvider {
-  id: string;
-  name: string;
-  dependencies?: string[];        // resolution ordering
-  requiredAffordances?: Affordance[]; // engine fails fast if unmet on retrieval
-  resolve(context: ProviderContext): Promise<{ nodes: KBNode[]; edges: KBEdge[] }>;
-}
-```
+graph fragment of nodes + edges. Every provider carries an `id`/`name`, an
+optional `dependencies` list that fixes its resolution order, an optional
+`requiredAffordances` the engine checks before running it, and a `resolve()`
+method returning `{ nodes, edges }`. See the
+[`GraphProvider` interface](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/provider.ts)
+for the exact shape.
 
 A provider may declare:
 
@@ -345,14 +335,11 @@ runs; it is transparent to the contract and produces the same `KBGraph`.
 
 A **`Representation`**
 ([`representation.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/representation.ts))
-renders the **pure** `KBGraph` (plus options) for a target:
-
-```ts
-interface Representation<Out = string> {
-  target: RepresentationTarget;   // 'spa' | 'json-ld' | 'llm-context' | (open)
-  render(graph: KBGraph, options?: RepresentationOptions): Out | Promise<Out>;
-}
-```
+renders the **pure** `KBGraph` (plus options) for a target: it names an open
+`target` string (`'spa'` | `'json-ld'` | `'llm-context'` | …) and implements
+`render(graph, options?)`. See the
+[`Representation` interface](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/representation.ts)
+for the exact shape.
 
 A [`RepresentationRegistry`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/registry.ts)
 maps a target name to its implementation (parallel to the provider registry).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -42,6 +42,7 @@ flowchart LR
 - [Layer 2 — Providers](#layer-2--providers)
 - [Layer 3 — Engine](#layer-3--engine)
 - [Layer 4 — Representation](#layer-4--representation)
+- [Search — a first-class representation over the graph](#search--a-first-class-representation-over-the-graph)
 - [Cross-cutting — identity & relations](#cross-cutting--identity--relations)
 - [The do-seam — affordances as a protocol-neutral action layer](#the-do-seam--affordances-as-a-protocol-neutral-action-layer)
 - [Extension points](#extension-points)
@@ -416,6 +417,80 @@ deliberately kept *out* of the pure data types in core.
 
 ---
 
+## Search — a first-class representation over the graph
+
+The four layers above are about *rendering* the graph. A sibling module —
+[`kbexplorer-search`](https://github.com/anokye-labs/kbexplorer-search), its
+own repo and package, not a `RepresentationTarget` registered inside
+`kbexplorer-template` — consumes the same graph for a different purpose:
+**semantic search**. The layering contract stays exactly as everywhere else in
+this document:
+
+> **kbexplorer defines and renders the knowledge graph; `kbexplorer-search`
+> derives, validates, and serves semantic search over it.**
+
+It is driven end-to-end through the
+[`kbx` CLI](https://github.com/anokye-labs/kbexplorer-cli), never invoked
+directly by a content author:
+
+```mermaid
+flowchart LR
+  Content[("content/<br/>knowledge graph")]
+  Index["kbx search-index<br/>extract + embed"]
+  Artifacts[(".search/<br/>index-meta.json · units.json · vectors.json")]
+  Serve["kbx search-serve /<br/>npx kbexplorer-search serve"]
+  SPA["kbexplorer-template SPA<br/>POST /search"]
+  Content --> Index --> Artifacts --> Serve --> SPA
+```
+
+### Index production
+
+`kbx search-index` reads the knowledge graph, derives searchable units,
+generates embeddings through a pluggable provider, and writes **checked-in,
+deterministic artifacts** (`index-meta.json`, `units.json`, `vectors.json`) —
+the repository owns the search corpus; no hosted service is required to
+produce it. `kbx search-index --check` is a pure, no-API-call drift gate
+suitable for CI, the same checked-in-artifact-plus-drift-gate pattern kbx
+already uses for cross-source connection artifacts (see
+[history.md](history.md)).
+
+### Index consumption
+
+`kbx search-serve` (equivalently `npx @anokye-labs/kbexplorer-search serve
+--dir .search --port <port>`) loads the checked-in artifacts, builds an
+in-memory vector index, embeds incoming queries, and exposes a small HTTP
+contract (`GET /health`, `GET /stats`, `POST /search`) that returns
+kbexplorer-native results — node IDs, titles, paths, clusters, snippets,
+scores, and graph-aware context.
+[`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) is
+the reference consumer: its SPA calls `POST /search` against whatever service
+`VITE_SEARCH_SERVICE_URL` points at.
+
+### Access labels — search never evaluates principals
+
+Search respects the same access labels carried on nodes and edges: by
+default, restricted/confidential/unknown content produces no search unit and
+no vector at all (it cannot leak via search, not even a title), or can be
+opted into an index-but-label posture for host-side filtering. As everywhere
+else in kbx, kbx **labels**, the host **enforces** — search performs no
+principal evaluation of its own. See the [access labels section of the
+`kbexplorer-search` README](https://github.com/anokye-labs/kbexplorer-search#access-labels)
+for the exact contract; this document does not restate the types.
+
+### Status
+
+Tracked end to end by
+[kbexplorer-search#5](https://github.com/anokye-labs/kbexplorer-search/issues/5)
+("Epic: make kbexplorer-search a first-class part of the kbx system"). As of
+this writing, `kbexplorer-search` still inlines a mirror of the core graph
+types rather than depending on `@anokye-labs/kbexplorer-core` directly
+([search#7](https://github.com/anokye-labs/kbexplorer-search/issues/7)); the
+`serve` bin and template contract parity (`graphRanking` / `suggestions`)
+landed via
+[search#6](https://github.com/anokye-labs/kbexplorer-search/issues/6).
+
+---
+
 ## Cross-cutting — identity & relations
 
 Two small contracts keep representations of the same real-world entity lined up
@@ -672,6 +747,7 @@ guard enforces for the built-ins.
 | Providers | [`provider.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/provider.ts) | [`src/engine/providers.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/providers.ts) · [`plugin-loader.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/plugin-loader.ts) |
 | Engine | [`graph.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/graph.ts) | [`loader.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/loader.ts) · [`orchestrator.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/orchestrator.ts) · [`transforms.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/transforms.ts) |
 | Representation | [`representation.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/representation.ts) | [`src/representation/`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/representation/registry.ts) |
+| Search (index production + consumption) | *(not yet — search#7)* | [`kbexplorer-search`](https://github.com/anokye-labs/kbexplorer-search) (separate repo/package), driven by [`kbx search-index` / `kbx search-serve`](https://github.com/anokye-labs/kbexplorer-cli) → [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) SPA (`POST /search`) |
 | Identity / relations | [`identity.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/identity.ts) · [`relations.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/relations.ts) | — |
 
 Related repos: the


### PR DESCRIPTION
## Summary
Umbrella/docs slice of the kbexplorer#102 wave. Prose only — no app code (per this repo's AGENTS.md).

## Changes
- `docs`: documents kbexplorer-search as a first-class representation over the graph in `docs/architecture.md` (index production via `kbx search-index`, consumption via the HTTP service → template SPA). Refs #11
- `docs(architecture)`: replaces verbatim reproductions of kbexplorer-core interfaces (`Resource`, `GraphProvider`, `Representation`) with links to the canonical source, per this repo's link-don't-copy policy. Refs #104
- `docs(agents)`: AGENTS.md — `refs #X` not `closes #X`, "check don't assume" branch-protection language (Refs #105), shared GitHub & Work-Item Conventions block

## Verification
- [x] Showcase deploy verified: last 5 `showcase.yml` runs green; it builds from source. Live-URL fetch blocked by this sandbox's egress policy — flagged for a maintainer spot-check.
- Evidence recorded on #104

## Merge order
Independent (depends on nothing) — merge any time. Full DAG: #102. Note the `dependency-review` check will be red until the Dependency Graph setting is enabled (#103) — a repo setting, not this PR.

Refs #11 #104 #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhaVWXhZtGHyfsFa26eSew

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhaVWXhZtGHyfsFa26eSew)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/anokye-labs/kbexplorer/pull/107" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->