### PR TITLE
chore: bump showcase TEMPLATE_REF v0.4.0 to v0.4.1

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -26,7 +26,7 @@ on:
 # template release ships (the template advises host repos to pin to a tag, not main).
 env:
   TEMPLATE_REPO: anokye-labs/kbexplorer-template
-  TEMPLATE_REF: v0.4.0
+  TEMPLATE_REF: v0.4.1
 
 permissions:
   contents: read


### PR DESCRIPTION
Bumps the live showcase's pinned template release **v0.4.0 → v0.4.1**.

## What v0.4.1 delivers over v0.4.0
- **template #453/#455** — the bespoke `copilot` target's `/constellation` route now renders a full-viewport **interactive** constellation instead of the decorative, non-interactive hero band.
- Already carried in v0.4.0 (context): **template #435** constellation rendering-quality fix (node overlap, label collision+truncation, edge clipping to node borders, node-identity legend, and full-label-on-select/hover).

## Change
`.github/workflows/showcase.yml`: `TEMPLATE_REF: v0.4.0` → `v0.4.1` (one line).

## Verification
Post-merge: confirm the showcase deploy run succeeds and https://anokye-labs.github.io/kbexplorer/ builds against v0.4.1.

Closes #120