### PR TITLE
docs(graph-build): add graph-build doc set with animated pipeline diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ This repo holds **no application code**. The code lives in:
     three interchangeable delivery adapters (extension-tool, MCP, canvas),
   - the provider and representation **extension points** (bring your own local or
     third-party providers and render targets).
+- [`docs/graph-build/`](docs/graph-build/) — a visual, step-by-step walkthrough of
+  **how the knowledge graph is built**: the baked-vs-live source swap and the
+  Sources → Providers → Engine → Representation pipeline, each stage fronted by an
+  animated diagram. The narrative companion to the architecture doc's engine layer.
 - [`docs/surfaces.md`](docs/surfaces.md) — the **two render surfaces** over the
   same graph: the human-facing SPA showcase (GitHub Pages) and the
   agent-facing embeddable Copilot canvas (served by `kbexplorer-cli` over a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -258,6 +258,11 @@ The engine is the single assembly path that resolves providers and emits a
 **pure `KBGraph`** — data only, no styling, no rendering, no I/O. This is the
 stable artifact everything downstream consumes.
 
+> For a visual, step-by-step walkthrough of this pipeline — the baked-vs-live
+> source swap, `registerProviders`, the orchestrator's transforms, and
+> `buildGraph` — see [`docs/graph-build/`](graph-build/), where each stage is
+> fronted by an animated diagram.
+
 `loadKnowledgeBase(source, config)`
 ([`loader.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/loader.ts))
 is the one entry point:

--- a/docs/graph-build/README.md
+++ b/docs/graph-build/README.md
@@ -1,0 +1,75 @@
+# Graph build
+
+How a kbx knowledge base is **built** — the path from a repository's content to a
+pure graph and, finally, to something a person or an agent can read. Where
+[workflows](../workflows/) cover the *operational* "how" of running a dataset,
+this set opens the box and traces the *internal* pipeline: one repository, two
+possible sources, one engine, four interchangeable render targets.
+
+These pages are the narrative companion to
+[Layer 3 — Engine](../architecture.md#layer-3--engine) in the architecture doc.
+Where architecture states the contract, these pages walk it end to end, each
+fronted by an animated diagram of the stage it describes.
+
+| Document | What it covers |
+|----------|---------------|
+| [Baked vs live](baked-vs-live.md) | The one pipeline fed by two sources. `VITE_KB_LOCAL=true` selects a build-time-baked manifest (zero API calls); the default selects the live GitHub API. Both converge on `loadKnowledgeBase(source, config)`. |
+| [Sources → RepoData](sources-to-repodata.md) | The `Source` contract (`retrieve` / `get`), `getRepoData()` → `RepoData`, affordances advertised **per retrieval**, and the git ≠ GitHub composite. |
+| [Providers → graph](providers-to-graph.md) | `registerProviders`, `orchestrateWithTransforms` (collect → transform → cluster → build), `DEFAULT_TRANSFORMS`, and how `buildGraph` derives the deduped, connected `KBGraph`. |
+| [Graph → representation](graph-to-representation.md) | The pure `KBGraph` → `RepresentationRegistry` → four targets (`spa`, `json-ld`, `llm-context`, `copilot`), and the purity guarantee that keeps the data targets engine-free. |
+
+## How to read the diagrams
+
+Each page opens with a hand-authored, animated SVG in the same visual language as
+the [workflows](../workflows/) diagrams: three horizontal bands, with numbered
+steps flowing left → right.
+
+- **People · surfaces** (teal, top) — what humans and agents finally consume:
+  the rendered SPA, or the `json-ld` / `llm-context` / `copilot` targets.
+- **The overlay · kbx** (violet, middle) — what kbx itself does: the `Source`,
+  `getRepoData`, the providers, the orchestrator, `buildGraph`, and the
+  representation registry.
+- **Host · systems of record** (slate, bottom) — where the bytes actually live:
+  `config.yaml` and `content/*.md` in git, the live GitHub API, and the
+  build-time-baked `repo-manifest.json`.
+
+The band mapping is deliberately the *same* as the workflows set, so the two
+reading experiences compose: inputs sit in the host band, everything kbx does
+sits in the overlay, and the surfaces people touch sit on top. Steps pop in and
+edges draw in sequence, then the diagram holds, fades, and rebuilds — a build-up
+idiom, because a graph is *assembled*, not handed over whole. Animation is pure
+CSS and honors `prefers-reduced-motion`.
+
+## Reading order
+
+Read them in pipeline order:
+
+1. [Baked vs live](baked-vs-live.md) — the two ways bytes enter, and where they
+   converge. Start here for the big picture.
+2. [Sources → RepoData](sources-to-repodata.md) — how a source turns a system of
+   record into one normalized `RepoData` bundle.
+3. [Providers → graph](providers-to-graph.md) — how providers, transforms, and
+   `buildGraph` derive the pure graph.
+4. [Graph → representation](graph-to-representation.md) — how that one graph
+   becomes a website, JSON-LD, an LLM context, or a canvas.
+
+## Grounding
+
+Every code fact on these pages is grounded against
+[`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) at
+tag **`v0.4.1`** — the ref the
+[showcase pins](../../.github/workflows/showcase.yml) (`TEMPLATE_REF`). Template
+file links point at that tag so the referenced lines match the prose. Per the
+repo's convention, type-level contracts link to their canonical definitions in
+[`kbexplorer-core`](https://github.com/anokye-labs/kbexplorer-core) rather than
+being re-described here.
+
+## Related documentation
+
+- [Architecture](../architecture.md) — the four-layer model
+  (Sources → Providers → Engine → Representation) these pages walk through.
+  In particular [Layer 3 — Engine](../architecture.md#layer-3--engine).
+- [Surfaces](../surfaces.md) — the two render surfaces over the same graph: the
+  human-facing SPA and the agent-facing embeddable Copilot canvas.
+- [Workflows](../workflows/) — the operational companion: creating, hosting,
+  updating, and governing a dataset day to day.

--- a/docs/graph-build/baked-vs-live.md
+++ b/docs/graph-build/baked-vs-live.md
@@ -1,0 +1,107 @@
+# Baked vs live
+
+The kbx explorer runs the **same pipeline** whether it is reading a live
+repository or a frozen snapshot. There is exactly one assembly path —
+`loadKnowledgeBase(source, config)` — and the *only* thing that changes between a
+zero-backend static deploy and a live-fetching build is **which `Source` gets
+constructed**. The crux: **baked vs live is a source swap, not a code fork** —
+everything downstream of the source is byte-for-byte the same.
+
+![Baked vs live — one pipeline fed by two sources: a build-time-baked manifest, or the live GitHub API, both converging on loadKnowledgeBase](baked-vs-live.svg)
+
+This page is the entry point for the [graph-build set](README.md); the three that
+follow zoom into the stages this one shows end to end.
+
+## One hook, two loaders
+
+At runtime the SPA calls a single hook,
+[`useKnowledgeBase()`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/hooks/useKnowledgeBase.ts).
+It asks
+[`detectLocalMode()`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/local-loader.ts)
+one question — is `import.meta.env.VITE_KB_LOCAL === 'true'`? — and branches to
+one of two thin loaders:
+
+| Mode | Selected when | Loader | Source |
+|------|---------------|--------|--------|
+| **Local (baked)** | `VITE_KB_LOCAL=true` | [`loadLocalKnowledgeBase()`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/local-loader.ts) | [`ManifestSource`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/sources/manifest-source.ts) over the baked manifest |
+| **Remote (live)** | default | [`loadRemoteKnowledgeBase()`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/remote-loader.ts) | [`GitHubApiSource`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/sources/github-api-source.ts) over the live GitHub API |
+
+Both loaders are **thin entry points**. `loadRemoteKnowledgeBase` constructs a
+`GitHubApiSource` for a resolution preset (`summary` · `standard` · `full`) and
+delegates; `loadLocalKnowledgeBase` constructs a `ManifestSource` from the
+imported manifest and delegates. Neither carries pipeline logic of its own —
+they only decide the source, then call the same
+[`loadKnowledgeBase(source, config)`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/loader.ts).
+
+## The bake: content → manifest, at build time
+
+Local mode reads a **build-time artifact**, not the network. Before the SPA is
+bundled, `npm run prebuild` runs
+[`scripts/generate-manifest.js`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/scripts/generate-manifest.js),
+whose `generateManifest()` walks the host repository and writes
+`src/generated/repo-manifest.json`. That single JSON file captures everything a
+source would otherwise fetch:
+
+- `readConfig()` — the raw `config.yaml`.
+- `readAuthoredContent()` — every `.md` under the content directory
+  (`VITE_KB_PATH`, default `content/`).
+- `walkFileSystem()` — the file tree; `readReadme()` — the README.
+- `fetchLocalIssues()` / `fetchLocalPullRequests()` / `fetchLocalCommits()` /
+  `fetchLocalBranches()` / `fetchRepoMetadata()` — read from the **local git
+  checkout and `gh`**, not the API, at bake time.
+- structural files, nodemap, and content-model data.
+
+`detectHostRoot()` decides *which* repository to bake (an explicit
+`VITE_KB_HOST_ROOT` always wins). The result is a frozen, self-contained
+snapshot — which is why the deployed
+[showcase](../../README.md#live-showcase) needs **no token and no backend**: the
+graph was fully resolved before deploy.
+
+## The live path: fetch at runtime
+
+Remote mode skips the bake entirely. `GitHubApiSource` performs the same
+retrievals against the **live GitHub REST/GraphQL API** when the page loads,
+honoring the resolution preset to bound how much it pulls. A live build always
+reflects the current repository, at the cost of API calls (and rate limits) on
+each load.
+
+## Where they converge
+
+```mermaid
+flowchart TB
+  subgraph baked["Baked (local)"]
+    direction TB
+    G1["content in git"] --> M["generate-manifest.js<br/>→ repo-manifest.json"] --> MS["ManifestSource"]
+  end
+  subgraph live["Live (remote)"]
+    direction TB
+    API["GitHub API"] --> GS["GitHubApiSource"]
+  end
+  MS --> L["loadKnowledgeBase(source, config)"]
+  GS --> L
+  L --> KG[("one pure KBGraph")]
+```
+
+From `loadKnowledgeBase` onward the two modes are indistinguishable: the same
+`source.getRepoData()` call, the same providers, the same
+[`buildGraph`](providers-to-graph.md), the same
+[representations](graph-to-representation.md). A baked deploy and a live build of
+the same commit produce the **same graph** — the bake just moves the fetch from
+page-load time to build time.
+
+## Next
+
+- [Sources → RepoData](sources-to-repodata.md) — what a `Source` actually
+  returns, and why affordances are advertised per retrieval.
+- [Providers → graph](providers-to-graph.md) — how `RepoData` becomes a pure
+  graph.
+
+---
+
+> The four-layer model behind this is in
+> [`docs/architecture.md`](../architecture.md) — see
+> [Layer 3 — Engine](../architecture.md#layer-3--engine) for the same two
+> loaders framed as thin wrappers over one assembly path. Code facts on this
+> page are grounded against
+> [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) at
+> tag `v0.4.1`.

--- a/docs/graph-build/baked-vs-live.svg
+++ b/docs/graph-build/baked-vs-live.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif" role="img" aria-labelledby="t d">
+  <title id="t">Baked vs live: one pipeline, two sources</title>
+  <desc id="d">A three-band pipeline. In the host band, content lives in git and is either baked into a manifest at build time or read live from the GitHub API. In the kbx overlay band, loadKnowledgeBase consumes whichever source. In the people band, one pure graph renders as the explorer SPA.</desc>
+  <defs>
+    <linearGradient id="node" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#faf5ff"/>
+      <stop offset="1" stop-color="#f3f0ff"/>
+    </linearGradient>
+    <filter id="cs" x="-4%" y="-12%" width="108%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#6d28d9" flood-opacity="0.12"/>
+    </filter>
+    <filter id="ss" x="-12%" y="-24%" width="124%" height="156%">
+      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#0f172a" flood-opacity="0.10"/>
+    </filter>
+    <marker id="m-human" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-kbx" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-host" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#64748b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+    g[class^="st"],path[class^="ed"]{animation-duration:16s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+    g[class^="st"]{transform-box:fill-box;transform-origin:center}
+    @keyframes st0{0%{opacity:0;transform:scale(.6)}2.0%{opacity:0;transform:scale(.6)}4.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st0{animation-name:st0}
+    @keyframes st1{0%{opacity:0;transform:scale(.6)}16.7%{opacity:0;transform:scale(.6)}18.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st1{animation-name:st1}
+    @keyframes st2{0%{opacity:0;transform:scale(.6)}31.4%{opacity:0;transform:scale(.6)}33.6%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st2{animation-name:st2}
+    @keyframes st3{0%{opacity:0;transform:scale(.6)}46.0%{opacity:0;transform:scale(.6)}48.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st3{animation-name:st3}
+    @keyframes st4{0%{opacity:0;transform:scale(.6)}60.7%{opacity:0;transform:scale(.6)}62.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st4{animation-name:st4}
+    @keyframes ed0{0%{stroke-dashoffset:var(--len);opacity:0}9.3%{stroke-dashoffset:var(--len);opacity:0}9.7%{opacity:1}12.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed0{animation-name:ed0}
+    @keyframes ed1{0%{stroke-dashoffset:var(--len);opacity:0}38.6%{stroke-dashoffset:var(--len);opacity:0}39.0%{opacity:1}41.6%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed1{animation-name:ed1}
+    @keyframes ed2{0%{stroke-dashoffset:var(--len);opacity:0}38.6%{stroke-dashoffset:var(--len);opacity:0}39.0%{opacity:1}41.6%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed2{animation-name:ed2}
+    @keyframes ed3{0%{stroke-dashoffset:var(--len);opacity:0}53.3%{stroke-dashoffset:var(--len);opacity:0}53.7%{opacity:1}56.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed3{animation-name:ed3}
+    @media (prefers-reduced-motion:reduce){g[class^="st"],path[class^="ed"]{animation:none!important;opacity:1!important;stroke-dashoffset:0!important}}
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#ffffff"/>
+
+  <text x="800" y="48" text-anchor="middle" font-size="30" font-weight="800" fill="#111827">Baked vs live: one pipeline, two sources</text>
+  <text x="800" y="78" text-anchor="middle" font-size="16" fill="#6b7280">VITE_KB_LOCAL picks a build-time manifest or the live GitHub API — everything downstream is identical</text>
+
+  <text x="80" y="120" font-size="14" font-weight="700" letter-spacing="2" fill="#0d9488">PEOPLE · SURFACES</text>
+
+  <rect x="80" y="300" width="1440" height="280" rx="12" fill="url(#card)" stroke="#ddd6fe" stroke-width="1.5" filter="url(#cs)"/>
+  <text x="110" y="334" font-size="14" font-weight="700" letter-spacing="2.5" fill="#6d28d9">THE OVERLAY · kbx</text>
+
+  <text x="80" y="790" font-size="14" font-weight="700" letter-spacing="2" fill="#475569">HOST · SYSTEMS OF RECORD</text>
+
+    <path class="ed0" d="M224,642 L224,469 Q224,455 238,455 L395,455" fill="none" stroke="#475569" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-host)" stroke-dasharray="368" style="--len:368"/>
+    <path class="ed1" d="M622,455 L971,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="359" style="--len:359"/>
+    <path class="ed2" d="M800,642 L800,469 Q800,455 814,455 L971,455" fill="none" stroke="#475569" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-host)" stroke-dasharray="368" style="--len:368"/>
+    <path class="ed3" d="M1088,417 L1088,219 Q1088,205 1102,205 L1259,205" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="393" style="--len:393"/>
+
+    <g class="st0">
+    <rect x="114" y="642" width="220" height="76" rx="10" fill="#ffffff" stroke="#475569" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(304,652) scale(0.8)" fill="none" stroke="#475569" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="6" rx="7.5" ry="3"/><path d="M4.5,6 v12 c0,1.7 3.4,3 7.5,3 s7.5,-1.3 7.5,-3 v-12"/><path d="M4.5,12 c0,1.7 3.4,3 7.5,3 s7.5,-1.3 7.5,-3"/></g>
+    <text x="128" y="668" font-size="14" font-weight="600" fill="#111827">Content lives in git</text>
+    <text x="128" y="688" font-size="12" fill="#6b7280">config.yaml + content/*.md</text>
+    <text x="128" y="704" font-size="12" fill="#6b7280">in the host repository</text>
+    <circle cx="114" cy="642" r="12.5" fill="url(#node)"/>
+    <text x="114" y="646.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">1</text>
+    </g>
+    <g class="st1">
+    <rect x="402" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(592,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3.4"/><path d="M12,3.8 v2.6 M12,17.6 v2.6 M3.8,12 h2.6 M17.6,12 h2.6 M6.1,6.1 l1.8,1.8 M16.1,16.1 l1.8,1.8 M17.9,6.1 l-1.8,1.8 M7.9,16.1 l-1.8,1.8"/></g>
+    <text x="416" y="443" font-size="14" font-weight="600" fill="#111827">Bake at build time</text>
+    <text x="416" y="463" font-size="12" fill="#6b7280">generate-manifest.js →</text>
+    <text x="416" y="479" font-size="12" fill="#6b7280">src/generated/repo-manifest.json</text>
+    <circle cx="402" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="402" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">2</text>
+    </g>
+    <g class="st2">
+    <rect x="690" y="642" width="220" height="76" rx="10" fill="#ffffff" stroke="#475569" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(880,652) scale(0.8)" fill="none" stroke="#475569" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4,15 v3.2 c0,0.8 0.7,1.5 1.5,1.5 h13 c0.8,0 1.5,-0.7 1.5,-1.5 v-3.2"/><path d="M12,3.6 v10.2 M7.4,9.2 L12,13.8 16.6,9.2"/></g>
+    <text x="704" y="668" font-size="14" font-weight="600" fill="#111827">…or read it live</text>
+    <text x="704" y="688" font-size="12" fill="#6b7280">GitHubApiSource calls</text>
+    <text x="704" y="704" font-size="12" fill="#6b7280">the GitHub REST/GraphQL API</text>
+    <circle cx="690" cy="642" r="12.5" fill="url(#node)"/>
+    <text x="690" y="646.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">3</text>
+    </g>
+    <g class="st3">
+    <rect x="978" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1168,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12,3.6 l8,4.5 v8.9 l-8,4.5 -8,-4.5 v-8.9 z"/><path d="M4,8.1 l8,4.5 8,-4.5 M12,12.6 v8.9"/></g>
+    <text x="992" y="443" font-size="14" font-weight="600" fill="#111827">loadKnowledgeBase()</text>
+    <text x="992" y="463" font-size="12" fill="#6b7280">both sources converge here</text>
+    <text x="992" y="479" font-size="12" fill="#6b7280">source.getRepoData() → engine</text>
+    <circle cx="978" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="978" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">4</text>
+    </g>
+    <g class="st4">
+    <rect x="1266" y="167" width="220" height="76" rx="10" fill="#ffffff" stroke="#0d9488" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1456,177) scale(0.8)" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"/><path d="M3.6,12 h16.8 M12,3.4 c2.6,2.4 2.6,14.8 0,17.2 c-2.6,-2.4 -2.6,-14.8 0,-17.2"/></g>
+    <text x="1280" y="193" font-size="14" font-weight="600" fill="#111827">One pure graph, rendered</text>
+    <text x="1280" y="213" font-size="12" fill="#6b7280">explorer SPA in the browser</text>
+    <text x="1280" y="229" font-size="12" fill="#6b7280">baked deploy needs no token</text>
+    <circle cx="1266" cy="167" r="12.5" fill="url(#node)"/>
+    <text x="1266" y="171.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">5</text>
+    </g>
+
+  <text x="800" y="862" text-anchor="middle" font-size="14" fill="#94a3b8">Same graph, same code — the only difference is whether the bytes came from a baked manifest or a live API call.</text>
+</svg>

--- a/docs/graph-build/graph-to-representation.md
+++ b/docs/graph-build/graph-to-representation.md
@@ -1,0 +1,113 @@
+# Graph → representation
+
+The graph is done — `{ nodes, edges, clusters, related }`, pure data. Now it has
+to become something a person or an agent can actually use. kbx treats that as a
+**pure function of the graph**: a `Representation` names a target and renders the
+graph for it, and the four built-in targets are fully **interchangeable** behind
+one registry. The crux: **the graph is data, representations are renderers** —
+the same graph yields a website, a JSON-LD document, an LLM context pack, or a
+canvas, and swapping targets changes nothing upstream.
+
+![Graph → representation — the pure KBGraph resolves through the RepresentationRegistry to four interchangeable targets: spa, json-ld, llm-context, copilot](graph-to-representation.svg)
+
+This is the last stage of the [graph-build pipeline](README.md): the pure graph
+from [providers → graph](providers-to-graph.md) becomes an actual surface.
+
+## One registry, four targets
+
+[`createDefaultRegistry()`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/index.ts)
+pre-populates a shared `representationRegistry` with the four built-in targets:
+
+| Target | Renders | File |
+|--------|---------|------|
+| `spa` | the explorer website (React) | [`spa.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/spa.tsx) |
+| `json-ld` | a deterministic JSON-LD document | [`json-ld.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/json-ld.ts) |
+| `llm-context` | a neighbour-anchored, token-budgeted Markdown pack | [`llm-context.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/llm-context.ts) |
+| `copilot` | the embeddable canvas surface | [`copilot.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/copilot.tsx) |
+
+A [`RepresentationRegistry`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/registry.ts)
+maps a target name to its implementation. `resolve(target)` returns the
+representation or **throws** if none is registered — targets are addressed by
+name, exactly like providers in the engine. The `Representation` contract itself
+is the canonical one in
+[`kbexplorer-core/src/representation.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/representation.ts).
+
+## The SPA path: from graph to DOM
+
+The explorer website is just one `resolve` + `render`. In
+[`App.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/App.tsx):
+
+```tsx
+const spaView = representationRegistry
+  .resolve('spa')
+  .render(graph, { config, fluentTheme, landingPath }) as ReactNode;
+```
+
+The `spa` target's `render`
+([`spa.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/spa.tsx))
+calls `renderSpaRoutes(graph, options)`, which returns a React Router `<Routes>`
+tree over the graph:
+
+| Route | View |
+|-------|------|
+| `/node/home` | `HomePage` |
+| `/overview` | `OverviewView` |
+| `/node/:id` | `ReadingView` (via `ReadingRoute`) |
+| `/` and `*` | redirect to the resolved `landingPath` |
+
+That element tree is mounted to the DOM by
+[`main.tsx`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/main.tsx):
+
+```tsx
+createRoot(document.getElementById('root')!).render(<StrictMode><App /></StrictMode>);
+```
+
+So the full runtime chain is: `loadKnowledgeBase` → pure `KBGraph` →
+`resolve('spa').render(...)` → `<Routes>` → `createRoot(...).render(...)` → pixels.
+
+## The purity guarantee
+
+The reason a graph can fan out to four targets so cleanly is a hard boundary:
+**the data targets never import the engine.** `json-ld` and `llm-context` are
+pure functions of the `KBGraph` and its contracts — they cannot reach back into
+providers, sources, or `buildGraph`. This is not a convention; it is enforced by
+a guard test,
+[`no-engine-import.test.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/representation/targets/__tests__/no-engine-import.test.ts).
+
+`spa` (and `copilot`) are the intentional exemption: they legitimately render
+React, so they depend on view components — but still only on the graph as their
+data input. The graph never depends on any representation, and the deterministic
+targets never depend on the engine. That acyclic shape is what makes "same graph,
+many surfaces" true rather than aspirational.
+
+## Full circle
+
+```mermaid
+flowchart LR
+  KG[("pure KBGraph")] --> R["representationRegistry.resolve(target)"]
+  R --> SPA["spa → website"]
+  R --> JL["json-ld"]
+  R --> LC["llm-context"]
+  R --> CP["copilot canvas"]
+```
+
+From a repository's `config.yaml` and `content/`, through a source, providers,
+transforms, and `buildGraph`, to a pure graph — and out to whichever surface the
+moment calls for. That is how the knowledge graph is built.
+
+## Back to the start
+
+- [Baked vs live](baked-vs-live.md) — where the pipeline begins, and the two
+  ways bytes enter it.
+- [Surfaces](../surfaces.md) — the SPA and the embeddable Copilot canvas as two
+  representation targets over the same graph.
+
+---
+
+> Representation is [Layer 4](../architecture.md#layer-4--representation) of the
+> four-layer model in [`docs/architecture.md`](../architecture.md). The
+> `Representation` contract is defined in
+> [`kbexplorer-core/src/representation.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/representation.ts).
+> Template code facts are grounded against
+> [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) at
+> tag `v0.4.1`.

--- a/docs/graph-build/graph-to-representation.svg
+++ b/docs/graph-build/graph-to-representation.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif" role="img" aria-labelledby="t d">
+  <title id="t">Graph → representation</title>
+  <desc id="d">A three-band pipeline. The pure KBGraph enters from the host band. In the kbx overlay band the RepresentationRegistry resolves a target and App.tsx selects the spa target, whose render returns a React Router route tree. In the people band the same graph becomes the explorer website or, unchanged, the json-ld, llm-context and copilot targets.</desc>
+  <defs>
+    <linearGradient id="node" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#faf5ff"/>
+      <stop offset="1" stop-color="#f3f0ff"/>
+    </linearGradient>
+    <filter id="cs" x="-4%" y="-12%" width="108%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#6d28d9" flood-opacity="0.12"/>
+    </filter>
+    <filter id="ss" x="-12%" y="-24%" width="124%" height="156%">
+      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#0f172a" flood-opacity="0.10"/>
+    </filter>
+    <marker id="m-human" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-kbx" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-host" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#64748b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+    g[class^="st"],path[class^="ed"]{animation-duration:16s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+    g[class^="st"]{transform-box:fill-box;transform-origin:center}
+    @keyframes st0{0%{opacity:0;transform:scale(.6)}2.0%{opacity:0;transform:scale(.6)}4.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st0{animation-name:st0}
+    @keyframes st1{0%{opacity:0;transform:scale(.6)}16.7%{opacity:0;transform:scale(.6)}18.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st1{animation-name:st1}
+    @keyframes st2{0%{opacity:0;transform:scale(.6)}31.4%{opacity:0;transform:scale(.6)}33.6%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st2{animation-name:st2}
+    @keyframes st3{0%{opacity:0;transform:scale(.6)}46.0%{opacity:0;transform:scale(.6)}48.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st3{animation-name:st3}
+    @keyframes st4{0%{opacity:0;transform:scale(.6)}60.7%{opacity:0;transform:scale(.6)}62.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st4{animation-name:st4}
+    @keyframes ed0{0%{stroke-dashoffset:var(--len);opacity:0}9.3%{stroke-dashoffset:var(--len);opacity:0}9.7%{opacity:1}12.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed0{animation-name:ed0}
+    @keyframes ed1{0%{stroke-dashoffset:var(--len);opacity:0}24.0%{stroke-dashoffset:var(--len);opacity:0}24.4%{opacity:1}27.0%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed1{animation-name:ed1}
+    @keyframes ed2{0%{stroke-dashoffset:var(--len);opacity:0}38.6%{stroke-dashoffset:var(--len);opacity:0}39.0%{opacity:1}41.6%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed2{animation-name:ed2}
+    @keyframes ed3{0%{stroke-dashoffset:var(--len);opacity:0}53.3%{stroke-dashoffset:var(--len);opacity:0}53.7%{opacity:1}56.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed3{animation-name:ed3}
+    @media (prefers-reduced-motion:reduce){g[class^="st"],path[class^="ed"]{animation:none!important;opacity:1!important;stroke-dashoffset:0!important}}
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#ffffff"/>
+
+  <text x="800" y="48" text-anchor="middle" font-size="30" font-weight="800" fill="#111827">Graph → representation</text>
+  <text x="800" y="78" text-anchor="middle" font-size="16" fill="#6b7280">One pure KBGraph resolves to interchangeable targets — SPA, JSON-LD, LLM-context, Copilot</text>
+
+  <text x="80" y="120" font-size="14" font-weight="700" letter-spacing="2" fill="#0d9488">PEOPLE · SURFACES</text>
+
+  <rect x="80" y="300" width="1440" height="280" rx="12" fill="url(#card)" stroke="#ddd6fe" stroke-width="1.5" filter="url(#cs)"/>
+  <text x="110" y="334" font-size="14" font-weight="700" letter-spacing="2.5" fill="#6d28d9">THE OVERLAY · kbx</text>
+
+  <text x="80" y="790" font-size="14" font-weight="700" letter-spacing="2" fill="#475569">HOST · SYSTEMS OF RECORD</text>
+
+    <path class="ed0" d="M224,642 L224,469 Q224,455 238,455 L481.4,455" fill="none" stroke="#475569" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-host)" stroke-dasharray="454.4" style="--len:454.4"/>
+    <path class="ed1" d="M708.4,455 L798.2,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="99.8" style="--len:99.8"/>
+    <path class="ed2" d="M915.2,417 L915.2,162 Q915.2,148 929.2,148 L1143.8,148" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="507.6" style="--len:507.6"/>
+    <path class="ed3" d="M598.4,417 L598.4,262 Q598.4,248 612.4,248 L1143.8,248" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="724.4" style="--len:724.4"/>
+
+    <g class="st0">
+    <rect x="114" y="642" width="220" height="76" rx="10" fill="#ffffff" stroke="#475569" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(304,652) scale(0.8)" fill="none" stroke="#475569" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="6.5" r="2.4"/><circle cx="18.5" cy="7.5" r="2.4"/><circle cx="11" cy="18.5" r="2.4"/><path d="M6.9,8 L9.6,16.6 M16.7,9.3 L12.6,16.8 M7.2,6.9 L16.2,7.3"/></g>
+    <text x="128" y="668" font-size="14" font-weight="600" fill="#111827">The pure KBGraph</text>
+    <text x="128" y="688" font-size="12" fill="#6b7280">{ nodes, edges, clusters, related }</text>
+    <text x="128" y="704" font-size="12" fill="#6b7280">no engine, no DOM</text>
+    <circle cx="114" cy="642" r="12.5" fill="url(#node)"/>
+    <text x="114" y="646.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">1</text>
+    </g>
+    <g class="st1">
+    <rect x="488.4" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(678.4,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="3.5" width="7" height="7" rx="1.4"/><rect x="13.5" y="3.5" width="7" height="7" rx="1.4"/><rect x="3.5" y="13.5" width="7" height="7" rx="1.4"/><rect x="13.5" y="13.5" width="7" height="7" rx="1.4"/></g>
+    <text x="502.4" y="443" font-size="14" font-weight="600" fill="#111827">Resolve a target</text>
+    <text x="502.4" y="463" font-size="12" fill="#6b7280">RepresentationRegistry</text>
+    <text x="502.4" y="479" font-size="12" fill="#6b7280">resolve(target).render(graph)</text>
+    <circle cx="488.4" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="488.4" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">2</text>
+    </g>
+    <g class="st2">
+    <rect x="805.2" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(995.2,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11,3 l1.9,5.1 5.1,1.9 -5.1,1.9 -1.9,5.1 -1.9,-5.1 -5.1,-1.9 5.1,-1.9 z"/><path d="M18.4,14.5 l0.9,2.4 2.4,0.9 -2.4,0.9 -0.9,2.4 -0.9,-2.4 -2.4,-0.9 2.4,-0.9 z"/></g>
+    <text x="819.2" y="443" font-size="14" font-weight="600" fill="#111827">App.tsx selects 'spa'</text>
+    <text x="819.2" y="463" font-size="12" fill="#6b7280">render(graph, {config, theme})</text>
+    <text x="819.2" y="479" font-size="12" fill="#6b7280">→ renderSpaRoutes()</text>
+    <circle cx="805.2" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="805.2" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">3</text>
+    </g>
+    <g class="st3">
+    <rect x="1150.8" y="110" width="220" height="76" rx="10" fill="#ffffff" stroke="#0d9488" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1340.8,120) scale(0.8)" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8.6"/><path d="M3.6,12 h16.8 M12,3.4 c2.6,2.4 2.6,14.8 0,17.2 c-2.6,-2.4 -2.6,-14.8 0,-17.2"/></g>
+    <text x="1164.8" y="136" font-size="14" font-weight="600" fill="#111827">The explorer website</text>
+    <text x="1164.8" y="156" font-size="12" fill="#6b7280">Home · Overview · Reading</text>
+    <text x="1164.8" y="172" font-size="12" fill="#6b7280">createRoot(#root).render</text>
+    <circle cx="1150.8" cy="110" r="12.5" fill="url(#node)"/>
+    <text x="1150.8" y="114.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">4</text>
+    </g>
+    <g class="st4">
+    <rect x="1150.8" y="210" width="220" height="76" rx="10" fill="#ffffff" stroke="#0d9488" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1340.8,220) scale(0.8)" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6,3.6 h7.5 l4.5,4.5 v11.8 c0,0.6 -0.5,1.1 -1.1,1.1 h-9.8 c-0.6,0 -1.1,-0.5 -1.1,-1.1 v-15.2 c0,-0.6 0.5,-1.1 1.1,-1.1 z"/><path d="M13.5,3.6 v4.5 h4.5"/><path d="M8.5,12.5 h7 M8.5,15.8 h7 M8.5,9.2 h3.2"/></g>
+    <text x="1164.8" y="236" font-size="14" font-weight="600" fill="#111827">…or other targets</text>
+    <text x="1164.8" y="256" font-size="12" fill="#6b7280">json-ld · llm-context · copilot</text>
+    <text x="1164.8" y="272" font-size="12" fill="#6b7280">same graph, other renderers</text>
+    <circle cx="1150.8" cy="210" r="12.5" fill="url(#node)"/>
+    <text x="1150.8" y="214.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">5</text>
+    </g>
+
+  <text x="800" y="862" text-anchor="middle" font-size="14" fill="#94a3b8">The graph is data; representations are pure functions of it — json-ld and llm-context never import the engine.</text>
+</svg>

--- a/docs/graph-build/providers-to-graph.md
+++ b/docs/graph-build/providers-to-graph.md
@@ -37,6 +37,59 @@ change required. The full provider roster and their trigger conditions are
 tabulated in
 [architecture Layer 2](../architecture.md#layer-2--providers).
 
+## What about non-markdown files?
+
+Ingestion is **not** "markdown-only" — but it *is* selective and precise, and
+different inputs get very different treatment. Only a couple of paths turn a
+file's **contents** into rich nodes; the file tree contributes **thin**
+reference nodes; everything else contributes nothing on its own.
+
+| Input | Handled by | Result |
+|-------|-----------|--------|
+| Authored `content/**.md` | `readAuthoredContent` keeps only `.md` (`extname === '.md'`) → `AuthoredProvider` parses frontmatter | **rich** nodes |
+| Structured content model — `content-model/**.yaml` + `schema/*.yaml` + `context.jsonld` | `ContentModelProvider` (path from `structuredContent.path`, default `content-model/`) | **rich, typed** nodes |
+| Structural spine — `.github/**`, `CODEOWNERS` | `StructuralProvider` parses into node `data` | nodes |
+| `node-map.yaml` | `readStructuredNodeMap` maps arbitrary paths → structured nodes | nodes |
+| Tree files with a key extension — `.ts .tsx .md .json .yaml .yml .css` | `FilesProvider` → `treeToNodes` | **thin** node: path + filename + `contains` edge; contents **not** parsed |
+| Any other extension — `.py .go .pdf .png .docx …` | — | **no node** (at most listed inside a directory node; images resolve to display URLs) |
+| `package-lock.json`, `.gitignore`, `.eslintrc.json`, dotfiles | `SKIP_FILES` / dotfile guard | excluded |
+
+`KEY_EXTENSIONS` and `SKIP_FILES`, and the thin-node shape, live in
+[`parser.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/parser.ts);
+the markdown-only authored walk is `readAuthoredContent` in
+[`generate-manifest.js`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/scripts/generate-manifest.js).
+
+So a `.docx`, a `.txt`, or a `.py` file does **not** become a rich node by
+itself. Two shipped levers close that gap:
+
+1. **`kbx derive` — bake unstructured sources into structured artifacts.** The
+   [`kbexplorer-cli`](https://github.com/anokye-labs/kbexplorer-cli) `derive`
+   command extracts entities and relationships from unstructured inputs
+   (`.docx`, `.txt`, prose `.md`) into committed JSON-LD, each artifact carrying
+   a `kg://` identity, the
+   [six-relation taxonomy](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/relations.ts),
+   and a `source.ref` back to the origin document — idempotent, keyed by the
+   source's SHA-256. Those artifacts are then ingested like any other structured
+   content. See
+   [creating a dataset → §5 First derivation](../workflows/creating-a-dataset.md#5-first-derivation).
+2. **Bring-your-own provider — parse anything at build time.** A custom or
+   loadable provider can turn **any** file type into nodes with **zero engine
+   change**, declared in `config.yaml` under `providers:` as a local ES module
+   (`./`, `../`) or a bare npm package, classified and guarded by
+   `checkProviderCompatibility` in
+   [`plugin-loader.ts`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/plugin-loader.ts)
+   (absolute/URL specifiers are rejected — no remote code execution). The
+   `Provider` contract is
+   [core's `provider.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/provider.ts);
+   the template's
+   [`docs/providers.md`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/docs/providers.md)
+   walks through authoring one.
+
+> **Not yet shipped.** A richer per-source ingestion model — a `sources[]`
+> array, arbitrary markdown-folder sources, per-fence render rules — has been
+> *proposed*, but is **not** current behaviour at `v0.4.1`. This page documents
+> only what the template does today.
+
 ## orchestrateWithTransforms — collect, transform, cluster, build
 
 [`orchestrateWithTransforms(registry, config, { readme })`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/orchestrator.ts)

--- a/docs/graph-build/providers-to-graph.md
+++ b/docs/graph-build/providers-to-graph.md
@@ -1,0 +1,108 @@
+# Providers → graph
+
+`RepoData` is a bag of normalized facts; it is not yet a graph. Turning it into
+one is the engine's core job, and it happens in two moves: **providers** each
+contribute nodes from their slice of the data, then **`buildGraph`** derives the
+edges, repairs the topology, and indexes it. The crux: **providers declare
+nodes and connections; they never build edges** — edge derivation, deduplication,
+and repair are centralized in one deterministic function.
+
+![Providers → graph — registerProviders wires the built-ins, the orchestrator collects and transforms in dependency order, and buildGraph derives the pure KBGraph](providers-to-graph.svg)
+
+This is the second overlay stage. Its input is the `RepoData` from
+[sources → RepoData](sources-to-repodata.md); its output is the pure graph that
+[graph → representation](graph-to-representation.md) renders.
+
+## registerProviders — who contributes nodes
+
+[`registerProviders(registry, data)`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/loader.ts)
+wires the built-in providers onto a `ProviderRegistry`, each conditional on what
+the `RepoData` bundle actually contains:
+
+| Provider | Contributes | From |
+|----------|-------------|------|
+| `FilesProvider` | file/tree nodes | `data.tree`, `data.repo` |
+| `AuthoredProvider` | authored-content nodes | `data.authoredContent` / nodemap |
+| `AuthoredRichMarkdownProvider` | rich-Markdown fragment nodes | `data.authoredContent` |
+| `WorkProvider` | issue / PR / work nodes | work data |
+| `PersonProvider` | person nodes | people data |
+| `StructuralProvider` | structural-spine nodes | `data.structuralFiles` |
+| `ContentModelProvider` | typed content-model nodes | `data.contentModel` |
+
+Providers are also the **headline extension seam**: external providers declared
+in `config.providers` are loaded through
+[`plugin-loader`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/loader.ts)
+(`loadExternalProviders`) and registered alongside the built-ins — no engine
+change required. The full provider roster and their trigger conditions are
+tabulated in
+[architecture Layer 2](../architecture.md#layer-2--providers).
+
+## orchestrateWithTransforms — collect, transform, cluster, build
+
+[`orchestrateWithTransforms(registry, config, { readme })`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/orchestrator.ts)
+runs four ordered phases:
+
+```mermaid
+flowchart LR
+  C["collect<br/>collectProviderNodes()"] --> T["transform<br/>applyTransforms()"]
+  T --> X["cluster<br/>extractClusters()"]
+  X --> B["build<br/>buildGraph()"]
+```
+
+1. **collect** — `collectProviderNodes()` resolves providers in **dependency
+   order** (`registry.getExecutionOrder()`), threading the accumulated nodes so a
+   later provider can see what earlier ones produced.
+2. **transform** — `applyTransforms()` runs
+   [`DEFAULT_TRANSFORMS`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/transforms.ts)
+   in order (order is significant):
+   - `readmeTransform` — synthesize the README node and cross-link it.
+   - `issueDirectoryLinkTransform` — link each issue to directories its body
+     references (**before** the split, so links stay on the original node).
+   - `issueSplitTransform` — split any issue with 2+ headings into a parent plus
+     a node per section.
+3. **cluster** — `extractClusters()` groups nodes into clusters.
+4. **build** — `buildGraph()` derives the final graph.
+
+## buildGraph — deriving the pure graph
+
+[`buildGraph(nodes, clusters)`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/graph.ts)
+is the deterministic heart of the pipeline:
+
+1. **access gate** — `filterAccessWithheld(nodes)` drops access-withheld nodes
+   before anything is wired.
+2. **node map** — a `Map<id, node>` (last-wins); a cross-provider id collision
+   emits a warning, because edges and the related index resolve against this map.
+3. **edges** — for each `node.connections[]`, an edge is added and deduplicated
+   by a **directed semantic key** —
+   `` `${from}\u0000${to}\u0000${type}\u0000${relation ?? ''}` `` — so direction,
+   type, *and* relation all matter. Each `node.parent` yields a `parent → child`
+   `contains` edge; weight is `conn.weight ?? getEdgeWeight(type)`.
+4. **orphan reattachment** — any node with no edges is linked to a connected
+   **same-cluster sibling**, or, failing that, to the **highest-degree hub**, via
+   an inferred `related` edge — so the graph stays connected.
+5. **related index** — `computeRelated()` builds *undirected* adjacency (keeping
+   the highest weight between any pair), then ranks each node's neighbours by
+   weight (tie-break: neighbour degree) and keeps the top **12**.
+
+The result is a pure
+[`KBGraph`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/graph.ts)
+— `{ nodes, edges, clusters, related }` — data only, no styling and no I/O.
+
+> **Determinism.** `buildGraph` is deterministic for a fixed node set, which is
+> what lets the reference repo canonicalize the graph in golden tests. Any change
+> to the flow above must regenerate those goldens.
+
+## Next
+
+- [Graph → representation](graph-to-representation.md) — how this one graph
+  becomes a website, JSON-LD, an LLM context, or a canvas.
+
+---
+
+> The engine is [Layer 3](../architecture.md#layer-3--engine) of the four-layer
+> model in [`docs/architecture.md`](../architecture.md). Type-level contracts
+> (`KBGraph`, `KBNode`, `KBEdge`) are defined in
+> [`kbexplorer-core/src/graph.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/graph.ts).
+> Template code facts are grounded against
+> [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) at
+> tag `v0.4.1`.

--- a/docs/graph-build/providers-to-graph.svg
+++ b/docs/graph-build/providers-to-graph.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif" role="img" aria-labelledby="t d">
+  <title id="t">Providers → graph</title>
+  <desc id="d">A three-band pipeline. RepoData enters from the host band. In the kbx overlay band, registerProviders wires the built-in providers, the orchestrator collects nodes in dependency order and applies the default transforms, then clusters and buildGraph derive edges, contains relationships, orphan reattachment and a related index. In the people band the result is one pure KBGraph ready to render.</desc>
+  <defs>
+    <linearGradient id="node" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#faf5ff"/>
+      <stop offset="1" stop-color="#f3f0ff"/>
+    </linearGradient>
+    <filter id="cs" x="-4%" y="-12%" width="108%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#6d28d9" flood-opacity="0.12"/>
+    </filter>
+    <filter id="ss" x="-12%" y="-24%" width="124%" height="156%">
+      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#0f172a" flood-opacity="0.10"/>
+    </filter>
+    <marker id="m-human" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-kbx" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-host" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#64748b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+    g[class^="st"],path[class^="ed"]{animation-duration:16s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+    g[class^="st"]{transform-box:fill-box;transform-origin:center}
+    @keyframes st0{0%{opacity:0;transform:scale(.6)}2.0%{opacity:0;transform:scale(.6)}4.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st0{animation-name:st0}
+    @keyframes st1{0%{opacity:0;transform:scale(.6)}16.7%{opacity:0;transform:scale(.6)}18.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st1{animation-name:st1}
+    @keyframes st2{0%{opacity:0;transform:scale(.6)}31.4%{opacity:0;transform:scale(.6)}33.6%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st2{animation-name:st2}
+    @keyframes st3{0%{opacity:0;transform:scale(.6)}46.0%{opacity:0;transform:scale(.6)}48.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st3{animation-name:st3}
+    @keyframes st4{0%{opacity:0;transform:scale(.6)}60.7%{opacity:0;transform:scale(.6)}62.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st4{animation-name:st4}
+    @keyframes ed0{0%{stroke-dashoffset:var(--len);opacity:0}9.3%{stroke-dashoffset:var(--len);opacity:0}9.7%{opacity:1}12.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed0{animation-name:ed0}
+    @keyframes ed1{0%{stroke-dashoffset:var(--len);opacity:0}24.0%{stroke-dashoffset:var(--len);opacity:0}24.4%{opacity:1}27.0%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed1{animation-name:ed1}
+    @keyframes ed2{0%{stroke-dashoffset:var(--len);opacity:0}38.6%{stroke-dashoffset:var(--len);opacity:0}39.0%{opacity:1}41.6%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed2{animation-name:ed2}
+    @keyframes ed3{0%{stroke-dashoffset:var(--len);opacity:0}53.3%{stroke-dashoffset:var(--len);opacity:0}53.7%{opacity:1}56.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed3{animation-name:ed3}
+    @media (prefers-reduced-motion:reduce){g[class^="st"],path[class^="ed"]{animation:none!important;opacity:1!important;stroke-dashoffset:0!important}}
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#ffffff"/>
+
+  <text x="800" y="48" text-anchor="middle" font-size="30" font-weight="800" fill="#111827">Providers → graph</text>
+  <text x="800" y="78" text-anchor="middle" font-size="16" fill="#6b7280">Providers collect nodes, transforms reshape them, and buildGraph derives one pure KBGraph</text>
+
+  <text x="80" y="120" font-size="14" font-weight="700" letter-spacing="2" fill="#0d9488">PEOPLE · SURFACES</text>
+
+  <rect x="80" y="300" width="1440" height="280" rx="12" fill="url(#card)" stroke="#ddd6fe" stroke-width="1.5" filter="url(#cs)"/>
+  <text x="110" y="334" font-size="14" font-weight="700" letter-spacing="2.5" fill="#6d28d9">THE OVERLAY · kbx</text>
+
+  <text x="80" y="790" font-size="14" font-weight="700" letter-spacing="2" fill="#475569">HOST · SYSTEMS OF RECORD</text>
+
+    <path class="ed0" d="M224,642 L224,469 Q224,455 238,455 L395,455" fill="none" stroke="#475569" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-host)" stroke-dasharray="368" style="--len:368"/>
+    <path class="ed1" d="M622,455 L683,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="71" style="--len:71"/>
+    <path class="ed2" d="M910,455 L971,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="71" style="--len:71"/>
+    <path class="ed3" d="M1088,417 L1088,219 Q1088,205 1102,205 L1259,205" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="393" style="--len:393"/>
+
+    <g class="st0">
+    <rect x="114" y="642" width="220" height="76" rx="10" fill="#ffffff" stroke="#475569" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(304,652) scale(0.8)" fill="none" stroke="#475569" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12,3.6 l8,4.5 v8.9 l-8,4.5 -8,-4.5 v-8.9 z"/><path d="M4,8.1 l8,4.5 8,-4.5 M12,12.6 v8.9"/></g>
+    <text x="128" y="668" font-size="14" font-weight="600" fill="#111827">RepoData in</text>
+    <text x="128" y="688" font-size="12" fill="#6b7280">normalized host data:</text>
+    <text x="128" y="704" font-size="12" fill="#6b7280">tree · authored · work · people</text>
+    <circle cx="114" cy="642" r="12.5" fill="url(#node)"/>
+    <text x="114" y="646.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">1</text>
+    </g>
+    <g class="st1">
+    <rect x="402" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(592,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3.5" y="3.5" width="7" height="7" rx="1.4"/><rect x="13.5" y="3.5" width="7" height="7" rx="1.4"/><rect x="3.5" y="13.5" width="7" height="7" rx="1.4"/><rect x="13.5" y="13.5" width="7" height="7" rx="1.4"/></g>
+    <text x="416" y="443" font-size="14" font-weight="600" fill="#111827">registerProviders()</text>
+    <text x="416" y="463" font-size="12" fill="#6b7280">Files · Authored · Work · Person</text>
+    <text x="416" y="479" font-size="12" fill="#6b7280">Structural · ContentModel (+external)</text>
+    <circle cx="402" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="402" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">2</text>
+    </g>
+    <g class="st2">
+    <rect x="690" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(880,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12,3.6 l8.4,4.6 -8.4,4.6 -8.4,-4.6 z"/><path d="M3.6,13.2 l8.4,4.6 8.4,-4.6"/><path d="M3.6,17.4 l8.4,4.6 8.4,-4.6"/></g>
+    <text x="704" y="443" font-size="14" font-weight="600" fill="#111827">collect → transform</text>
+    <text x="704" y="463" font-size="12" fill="#6b7280">getExecutionOrder() dep order,</text>
+    <text x="704" y="479" font-size="12" fill="#6b7280">then DEFAULT_TRANSFORMS</text>
+    <circle cx="690" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="690" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">3</text>
+    </g>
+    <g class="st3">
+    <rect x="978" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1168,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="6.5" r="2.4"/><circle cx="18.5" cy="7.5" r="2.4"/><circle cx="11" cy="18.5" r="2.4"/><path d="M6.9,8 L9.6,16.6 M16.7,9.3 L12.6,16.8 M7.2,6.9 L16.2,7.3"/></g>
+    <text x="992" y="443" font-size="14" font-weight="600" fill="#111827">cluster → buildGraph</text>
+    <text x="992" y="463" font-size="12" fill="#6b7280">edges · contains · orphan reattach</text>
+    <text x="992" y="479" font-size="12" fill="#6b7280">top-12 related index</text>
+    <circle cx="978" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="978" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">4</text>
+    </g>
+    <g class="st4">
+    <rect x="1266" y="167" width="220" height="76" rx="10" fill="#ffffff" stroke="#0d9488" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1456,177) scale(0.8)" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M11,3 l1.9,5.1 5.1,1.9 -5.1,1.9 -1.9,5.1 -1.9,-5.1 -5.1,-1.9 5.1,-1.9 z"/><path d="M18.4,14.5 l0.9,2.4 2.4,0.9 -2.4,0.9 -0.9,2.4 -0.9,-2.4 -2.4,-0.9 2.4,-0.9 z"/></g>
+    <text x="1280" y="193" font-size="14" font-weight="600" fill="#111827">One pure KBGraph</text>
+    <text x="1280" y="213" font-size="12" fill="#6b7280">{ nodes, edges, clusters, related }</text>
+    <text x="1280" y="229" font-size="12" fill="#6b7280">ready to render</text>
+    <circle cx="1266" cy="167" r="12.5" fill="url(#node)"/>
+    <text x="1266" y="171.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">5</text>
+    </g>
+
+  <text x="800" y="862" text-anchor="middle" font-size="14" fill="#94a3b8">Providers never build edges themselves — they declare connections, and buildGraph derives the deduped, directed edge set.</text>
+</svg>

--- a/docs/graph-build/sources-to-repodata.md
+++ b/docs/graph-build/sources-to-repodata.md
@@ -1,0 +1,98 @@
+# Sources → RepoData
+
+Before a single node exists, kbx has to turn a *system of record* into something
+the engine can consume. That is the job of a **`Source`**: retrieve
+self-describing resources, then normalize them into one `RepoData` bundle. The
+crux: **a Source describes what it hands back — it doesn't just return data, it
+returns data that says what you're allowed to do with it**, and it says so **per
+retrieval**, never per type.
+
+![Sources → RepoData — a Source retrieves self-describing resources, models the git ≠ GitHub composite, and normalizes everything into one RepoData bundle](sources-to-repodata.svg)
+
+This page covers the first overlay stage from [baked vs live](baked-vs-live.md):
+whichever `Source` was chosen, this is the contract it satisfies. The type-level
+detail lives in the canonical contract —
+[`kbexplorer-core/src/source.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+and
+[§4A of the architecture doc](../architecture.md#4a-the-source--affordance-model) —
+so this page focuses on the shape of the flow rather than re-describing the
+types.
+
+## The contract
+
+A [`Source`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+exposes a small surface:
+
+- `retrieve(query)` → `Resource[]` — pull resources matching a query.
+- `get(href)` (optional) — re-retrieve a single resource by its locator.
+- `getRepoData()` → `Promise<RepoData>` — the **normalized bundle the engine
+  consumes** (config, authored content, tree, README, issues, PRs, and so on).
+
+Each [`Resource`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+carries an `href` locator for re-retrieval, an open `kind` string, its
+`affordances`, and hypermedia `links`. A consumer *navigates* the returned
+resources by following links — it never reconstructs URLs or infers capability
+from a resource's shape.
+
+## Affordances are advertised per retrieval
+
+This is the idea that makes the model composable. A source declares a *possible
+universe* of affordances via `possibleAffordances`, but that is **advisory
+only**. The authoritative set lives on **each retrieved `Resource`**, describing
+what is allowed *at the moment it was retrieved* — the same `href` can come back
+later with a different set.
+
+A consumer therefore asks
+[`hasAffordance(resource, 'write')`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+and follows the resource's own `links` (for example, the `staging-area` link a
+resource gains once it has been staged). It never assumes a capability from the
+resource's *type*. The full retrieval-context table — read-only vs. writable vs.
+staged — is in
+[§4A](../architecture.md#4a-the-source--affordance-model).
+
+## Git ≠ GitHub: one source, two families
+
+[`GitHubApiSource`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/sources/github-api-source.ts)
+is deliberately a **composite**. Git the version-control store and GitHub the
+collaboration platform are *different systems*, and the source models them as two
+resource families with non-overlapping addressing and affordances:
+
+| Family | Addressing | Kinds | Native affordances |
+|--------|-----------|-------|--------------------|
+| **Git** | `git://owner/repo/…` | `file` · `tree` · `commit` · `staging-area` | `read` · `write` · `stage` |
+| **GitHub** | `github://owner/repo/…` | `issue` · `pull-request` · `release` | `read` · `comment` · `close` · `merge` |
+
+The families never bleed into each other: a pull request's `merge` affordance
+never lands on a git `file`, and a git file's `stage` affordance never appears on
+an issue. Because `Affordance` and `kind` are **open strings**, a new source can
+introduce its own family without any engine change.
+
+By contrast,
+[`ManifestSource`](https://github.com/anokye-labs/kbexplorer-template/blob/v0.4.1/src/engine/sources/manifest-source.ts)
+is a **frozen snapshot** with a single affordance posture: every resource is
+`['read']` only, linked to `self` and nothing more. A baked manifest has no
+staging area because there is nothing to write back to — the same contract,
+honestly reporting a read-only world.
+
+## The output: one RepoData bundle
+
+Whichever source is in play, `getRepoData()` normalizes its retrievals into the
+one [`RepoData`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts)
+bundle the engine expects. That bundle is the hand-off point to the next stage —
+the providers turn it into graph nodes.
+
+## Next
+
+- [Providers → graph](providers-to-graph.md) — how `RepoData` becomes a pure
+  `KBGraph`.
+- Back to [baked vs live](baked-vs-live.md) for where the two sources are
+  chosen.
+
+---
+
+> Source, Resource, Affordance, and the staging model are defined once, in
+> [`kbexplorer-core/src/source.ts`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/source.ts);
+> [`docs/architecture.md` §4A](../architecture.md#4a-the-source--affordance-model)
+> is the reference narrative. Template code facts are grounded against
+> [`kbexplorer-template`](https://github.com/anokye-labs/kbexplorer-template) at
+> tag `v0.4.1`.

--- a/docs/graph-build/sources-to-repodata.md
+++ b/docs/graph-build/sources-to-repodata.md
@@ -81,6 +81,13 @@ one [`RepoData`](https://github.com/anokye-labs/kbexplorer-core/blob/main/src/so
 bundle the engine expects. That bundle is the hand-off point to the next stage —
 the providers turn it into graph nodes.
 
+`RepoData` carries a mix of shapes: authored **Markdown**, the structured
+**content model** (typed YAML + JSON-LD context), **structural** files
+(`.github/**`, `CODEOWNERS`), and a **thin file tree** (paths, not contents).
+Which file types actually become nodes — and how a `.docx` or `.txt` gets in via
+`kbx derive` or a bring-your-own provider — is covered in
+[providers → graph → *What about non-markdown files?*](providers-to-graph.md#what-about-non-markdown-files).
+
 ## Next
 
 - [Providers → graph](providers-to-graph.md) — how `RepoData` becomes a pure

--- a/docs/graph-build/sources-to-repodata.svg
+++ b/docs/graph-build/sources-to-repodata.svg
@@ -1,0 +1,117 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" font-family="'Inter','Segoe UI',system-ui,-apple-system,sans-serif" role="img" aria-labelledby="t d">
+  <title id="t">Sources → RepoData</title>
+  <desc id="d">A three-band pipeline. In the host band sit the systems of record: git files, trees and commits, plus GitHub issues, PRs and releases. In the kbx overlay band a Source retrieves self-describing resources, models the git-vs-GitHub composite, and getRepoData normalizes everything into RepoData. In the people band a consumer navigates by affordances and links.</desc>
+  <defs>
+    <linearGradient id="node" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#8b5cf6"/>
+      <stop offset="1" stop-color="#6366f1"/>
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#faf5ff"/>
+      <stop offset="1" stop-color="#f3f0ff"/>
+    </linearGradient>
+    <filter id="cs" x="-4%" y="-12%" width="108%" height="128%">
+      <feDropShadow dx="0" dy="10" stdDeviation="18" flood-color="#6d28d9" flood-opacity="0.12"/>
+    </filter>
+    <filter id="ss" x="-12%" y="-24%" width="124%" height="156%">
+      <feDropShadow dx="0" dy="5" stdDeviation="8" flood-color="#0f172a" flood-opacity="0.10"/>
+    </filter>
+    <marker id="m-human" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-kbx" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#7c3aed" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <marker id="m-host" viewBox="0 0 10 10" refX="6.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M1.5,1 L8.5,5 L1.5,9" fill="none" stroke="#64748b" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+    <style>
+    g[class^="st"],path[class^="ed"]{animation-duration:16s;animation-timing-function:ease-in-out;animation-iteration-count:infinite}
+    g[class^="st"]{transform-box:fill-box;transform-origin:center}
+    @keyframes st0{0%{opacity:0;transform:scale(.6)}2.0%{opacity:0;transform:scale(.6)}4.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st0{animation-name:st0}
+    @keyframes st1{0%{opacity:0;transform:scale(.6)}16.7%{opacity:0;transform:scale(.6)}18.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st1{animation-name:st1}
+    @keyframes st2{0%{opacity:0;transform:scale(.6)}31.4%{opacity:0;transform:scale(.6)}33.6%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st2{animation-name:st2}
+    @keyframes st3{0%{opacity:0;transform:scale(.6)}46.0%{opacity:0;transform:scale(.6)}48.2%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st3{animation-name:st3}
+    @keyframes st4{0%{opacity:0;transform:scale(.6)}60.7%{opacity:0;transform:scale(.6)}62.9%{opacity:1;transform:scale(1)}84%{opacity:1;transform:scale(1)}92%{opacity:0;transform:scale(.6)}100%{opacity:0;transform:scale(.6)}}
+    .st4{animation-name:st4}
+    @keyframes ed0{0%{stroke-dashoffset:var(--len);opacity:0}9.3%{stroke-dashoffset:var(--len);opacity:0}9.7%{opacity:1}12.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed0{animation-name:ed0}
+    @keyframes ed1{0%{stroke-dashoffset:var(--len);opacity:0}24.0%{stroke-dashoffset:var(--len);opacity:0}24.4%{opacity:1}27.0%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed1{animation-name:ed1}
+    @keyframes ed2{0%{stroke-dashoffset:var(--len);opacity:0}38.6%{stroke-dashoffset:var(--len);opacity:0}39.0%{opacity:1}41.6%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed2{animation-name:ed2}
+    @keyframes ed3{0%{stroke-dashoffset:var(--len);opacity:0}53.3%{stroke-dashoffset:var(--len);opacity:0}53.7%{opacity:1}56.3%{stroke-dashoffset:0;opacity:1}84%{stroke-dashoffset:0;opacity:1}92%{stroke-dashoffset:0;opacity:0}100%{stroke-dashoffset:var(--len);opacity:0}}
+    .ed3{animation-name:ed3}
+    @media (prefers-reduced-motion:reduce){g[class^="st"],path[class^="ed"]{animation:none!important;opacity:1!important;stroke-dashoffset:0!important}}
+    </style>
+  </defs>
+
+  <rect width="1600" height="900" fill="#ffffff"/>
+
+  <text x="800" y="48" text-anchor="middle" font-size="30" font-weight="800" fill="#111827">Sources → RepoData</text>
+  <text x="800" y="78" text-anchor="middle" font-size="16" fill="#6b7280">A Source retrieves self-describing resources and normalizes them into one RepoData bundle</text>
+
+  <text x="80" y="120" font-size="14" font-weight="700" letter-spacing="2" fill="#0d9488">PEOPLE · SURFACES</text>
+
+  <rect x="80" y="300" width="1440" height="280" rx="12" fill="url(#card)" stroke="#ddd6fe" stroke-width="1.5" filter="url(#cs)"/>
+  <text x="110" y="334" font-size="14" font-weight="700" letter-spacing="2.5" fill="#6d28d9">THE OVERLAY · kbx</text>
+
+  <text x="80" y="790" font-size="14" font-weight="700" letter-spacing="2" fill="#475569">HOST · SYSTEMS OF RECORD</text>
+
+    <path class="ed0" d="M224,642 L224,469 Q224,455 238,455 L395,455" fill="none" stroke="#475569" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-host)" stroke-dasharray="368" style="--len:368"/>
+    <path class="ed1" d="M622,455 L683,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="71" style="--len:71"/>
+    <path class="ed2" d="M910,455 L971,455" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="71" style="--len:71"/>
+    <path class="ed3" d="M1088,417 L1088,219 Q1088,205 1102,205 L1259,205" fill="none" stroke="#6d28d9" stroke-width="2.2" stroke-opacity="0.75" marker-end="url(#m-kbx)" stroke-dasharray="393" style="--len:393"/>
+
+    <g class="st0">
+    <rect x="114" y="642" width="220" height="76" rx="10" fill="#ffffff" stroke="#475569" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(304,652) scale(0.8)" fill="none" stroke="#475569" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="6" rx="7.5" ry="3"/><path d="M4.5,6 v12 c0,1.7 3.4,3 7.5,3 s7.5,-1.3 7.5,-3 v-12"/><path d="M4.5,12 c0,1.7 3.4,3 7.5,3 s7.5,-1.3 7.5,-3"/></g>
+    <text x="128" y="668" font-size="14" font-weight="600" fill="#111827">Systems of record</text>
+    <text x="128" y="688" font-size="12" fill="#6b7280">git: files · tree · commits</text>
+    <text x="128" y="704" font-size="12" fill="#6b7280">GitHub: issues · PRs · releases</text>
+    <circle cx="114" cy="642" r="12.5" fill="url(#node)"/>
+    <text x="114" y="646.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">1</text>
+    </g>
+    <g class="st1">
+    <rect x="402" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(592,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4,15 v3.2 c0,0.8 0.7,1.5 1.5,1.5 h13 c0.8,0 1.5,-0.7 1.5,-1.5 v-3.2"/><path d="M12,3.6 v10.2 M7.4,9.2 L12,13.8 16.6,9.2"/></g>
+    <text x="416" y="443" font-size="14" font-weight="600" fill="#111827">Source.retrieve()</text>
+    <text x="416" y="463" font-size="12" fill="#6b7280">returns self-describing</text>
+    <text x="416" y="479" font-size="12" fill="#6b7280">Resource[] with affordances</text>
+    <circle cx="402" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="402" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">2</text>
+    </g>
+    <g class="st2">
+    <rect x="690" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(880,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="6.5" cy="5" r="2.3"/><circle cx="6.5" cy="19" r="2.3"/><circle cx="17.5" cy="9" r="2.3"/><path d="M6.5,7.3 v9.4 M6.5,12 h6 c2.8,0 5,-2.2 5,-5"/></g>
+    <text x="704" y="443" font-size="14" font-weight="600" fill="#111827">Git ≠ GitHub</text>
+    <text x="704" y="463" font-size="12" fill="#6b7280">git:// read · write · stage</text>
+    <text x="704" y="479" font-size="12" fill="#6b7280">github:// comment · close · merge</text>
+    <circle cx="690" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="690" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">3</text>
+    </g>
+    <g class="st3">
+    <rect x="978" y="417" width="220" height="76" rx="10" fill="#ffffff" stroke="#6d28d9" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1168,427) scale(0.8)" fill="none" stroke="#6d28d9" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12,3.6 l8,4.5 v8.9 l-8,4.5 -8,-4.5 v-8.9 z"/><path d="M4,8.1 l8,4.5 8,-4.5 M12,12.6 v8.9"/></g>
+    <text x="992" y="443" font-size="14" font-weight="600" fill="#111827">getRepoData()</text>
+    <text x="992" y="463" font-size="12" fill="#6b7280">normalize retrievals into</text>
+    <text x="992" y="479" font-size="12" fill="#6b7280">one RepoData bundle</text>
+    <circle cx="978" cy="417" r="12.5" fill="url(#node)"/>
+    <text x="978" y="421.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">4</text>
+    </g>
+    <g class="st4">
+    <rect x="1266" y="167" width="220" height="76" rx="10" fill="#ffffff" stroke="#0d9488" stroke-opacity="0.5" stroke-width="1.6" filter="url(#ss)"/>
+    <g transform="translate(1456,177) scale(0.8)" fill="none" stroke="#0d9488" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="7.5" r="2.6"/><path d="M3.4,18.5 c0,-3.4 2.1,-5.2 4.6,-5.2 s4.6,1.8 4.6,5.2"/><circle cx="16.6" cy="9" r="2.2"/><path d="M15.4,13.6 c2.6,0 4.8,1.8 4.8,5.1"/></g>
+    <text x="1280" y="193" font-size="14" font-weight="600" fill="#111827">A consumer navigates</text>
+    <text x="1280" y="213" font-size="12" fill="#6b7280">hasAffordance(resource, "write")</text>
+    <text x="1280" y="229" font-size="12" fill="#6b7280">follow links, never assume by type</text>
+    <circle cx="1266" cy="167" r="12.5" fill="url(#node)"/>
+    <text x="1266" y="171.5" text-anchor="middle" font-size="13" font-weight="700" fill="#ffffff">5</text>
+    </g>
+
+  <text x="800" y="862" text-anchor="middle" font-size="14" fill="#94a3b8">Consumers ask hasAffordance(resource, "write") and follow links — they never infer capability from a URL scheme.</text>
+</svg>

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -60,6 +60,10 @@ in depth.
 
 - [Architecture](../architecture.md) — the four-layer model (Sources ->
   Providers -> Engine -> Representation).
+- [Graph build](../graph-build/) — the *internal* companion to these
+  operational workflows: how the graph is **built**, from the baked/live source
+  swap through providers, transforms, and `buildGraph` to the render targets —
+  each stage fronted by an animated diagram in this same visual language.
 - [Personas](../personas.md) · [Journeys](../journeys.md) ·
   [User stories](../user-stories.md) — who uses kbx and why.
 - [Adoption paved path](../adoption-paved-path.md) — making kbx integration


### PR DESCRIPTION
## What

Adds `docs/graph-build/` — a five-page walkthrough of **how the kbexplorer knowledge graph is built**, each page fronted by its own hand-authored animated SVG in the exact visual language of `docs/workflows/*.svg` (three bands, numbered step cards, elbow edges, 16s loop, `prefers-reduced-motion` fallback).

`refs #125`

### Pages
| Page | Covers |
|------|--------|
| `README.md` | Index — page table, "How to read the diagrams" (three-band idiom + reduced-motion), reading order, related docs |
| `baked-vs-live` | One pipeline, two Sources: `VITE_KB_LOCAL=true` → `ManifestSource` over a build-time-baked `repo-manifest.json` (zero API calls) vs default `GitHubApiSource` over the live API. Both converge on `loadKnowledgeBase(source, config)` |
| `sources-to-repodata` | The `Source` contract (`retrieve`/`get`/`getRepoData`), per-**retrieval** affordances, the git:// ≠ github:// composite |
| `providers-to-graph` | `registerProviders`, `orchestrateWithTransforms` (collect → transform → cluster → build), `DEFAULT_TRANSFORMS`, `buildGraph` → pure `KBGraph`. Includes a **file-type fidelity** section (below). |
| `graph-to-representation` | Pure `KBGraph` → `RepresentationRegistry` → four interchangeable targets (spa/json-ld/llm-context/copilot); the engine-import purity guard |

### File-type fidelity (non-markdown)
`providers-to-graph` includes a **"What about non-markdown files?"** section — a fidelity table (authored `.md` is markdown-only via `readAuthoredContent`; structured content model via `ContentModelProvider`; structural files + `node-map.yaml`; thin file-tree nodes via `treeToNodes` over `KEY_EXTENSIONS`; other extensions → no node) plus the **two shipped levers** for unstructured/non-markdown content: **`kbx derive`** (→ committed JSON-LD) and the **bring-your-own provider** seam (`config.yaml` `providers:`, guarded by `checkProviderCompatibility`). It explicitly flags the proposed `sources[]`/markdown-folder/per-fence model as **not shipped** at v0.4.1. `sources-to-repodata` cross-references it.

### Wiring
Cross-linked into the existing docs web: `docs/workflows/README.md` (Related documentation), top-level `README.md` (What's here), and `docs/architecture.md` Layer 3 (Engine).

## Grounding
All code facts are grounded against **`anokye-labs/kbexplorer-template` at tag `v0.4.1`** (the tag the showcase pins via `TEMPLATE_REF`). Per `AGENTS.md`, type contracts link to the canonical source in `kbexplorer-core` rather than being re-described.

## Verification
- ✅ All 4 SVGs are well-formed XML, contain the `prefers-reduced-motion` block, and pass a 0-collision layout check
- ✅ All 4 diagrams visually verified via headless static render
- ✅ All 48 internal path links + 12 heading anchors in the new docs resolve; the 3 reverse wiring links resolve; new external targets (`parser.ts`, `plugin-loader.ts`, template `docs/providers.md`, core `provider.ts`/`relations.ts`) verified live
- ✅ Docs-only change — no impact on `showcase-build`

## Notes for reviewers (drift found while grounding, out of scope here)
1. **`TEMPLATE_REF` mismatch**: `showcase.yml` pins `v0.4.1` but `showcase-build-check.yml` pins `v0.4.0`.
2. **`architecture.md` edge-key drift**: line ~311 says edges are keyed by the "unordered node pair", but `graph.ts@v0.4.1` `edgeKey()` uses a **directed** key (`from\0to\0type\0relation`). The new `providers-to-graph` page describes the directed behaviour accurately; I did not touch the architecture.md prose (out of scope). Flagging for a separate fix.