### PR TITLE
fix: correct template-ref skew and directed edge-key docs

### DIFF
--- a/.github/workflows/showcase-build-check.yml
+++ b/.github/workflows/showcase-build-check.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   TEMPLATE_REPO: anokye-labs/kbexplorer-template
-  TEMPLATE_REF: v0.4.0
+  TEMPLATE_REF: v0.4.1
 
 permissions:
   contents: read

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -308,7 +308,8 @@ Loaders carry **no** post-processing; they only build the `TransformContext`
 [`buildGraph(nodes, clusters)`](https://github.com/anokye-labs/kbexplorer-template/blob/main/src/engine/graph.ts):
 
 1. **edges** — each `node.connections[]` becomes a deduped `KBEdge`
-   (keyed by the unordered node pair) plus `parent → child` `contains` edges;
+   (deduplicated by a directed key of `from`, `to`, `type`, and `relation`, so
+   `A → B` is distinct from `B → A`) plus `parent → child` `contains` edges;
    weight is `conn.weight ?? getEdgeWeight(type)`.
 2. **orphan reattachment** — any edge-less node is linked to a connected
    same-cluster sibling (else the highest-degree hub) via an inferred `related`


### PR DESCRIPTION
Two pre-verified drift fixes, each traced to a filed Bug issue. Issue-first, `refs` only — closure is a deliberate, separate step per AGENTS.md.

### refs #127 — CI `TEMPLATE_REF` skew
`.github/workflows/showcase-build-check.yml` pinned `TEMPLATE_REF: v0.4.0` while the deploy workflow `.github/workflows/showcase.yml` pins `v0.4.1` (L29). The check file's own header (L8–9) requires keeping the two in sync, and `showcase-build` is a **required** gate — so it validated a different template version than what actually ships. Bumped to `v0.4.1` (the only change to that file).

**Evidence:** `showcase.yml` L29 = `v0.4.1`; sync invariant documented in `showcase-build-check.yml` L8–9.

### refs #128 — stale edge-key prose in `architecture.md`
The "Building the pure graph" bullet described the `KBEdge` dedup key as "keyed by the unordered node pair". The actual key in `kbexplorer-template` `src/engine/graph.ts` (`edgeKey()`) is **directed** — composed of `from`, `to`, `type`, and `relation`, so `A → B` is distinct from `B → A`. Reworded **only** the parenthetical to match; the rest of the bullet (the `contains` edges and weight clause) and the existing `graph.ts` link are untouched, and the link still resolves (HTTP 200).

**Evidence:** live `edgeKey()` on `main` returns a directed key `` `${from}\0${to}\0${type}\0${relation ?? ''}` ``.

### Notes
- The **optional** cross-reference to `docs/graph-build/providers-to-graph.md` (suggested in #128) was intentionally **not** added: that page still lives in the open PR #126 and does not yet exist on `main`, so linking it would introduce a broken link (violating the AGENTS.md "links resolve" rule).
- Leaves #127 and #128 **OPEN** — the deliberate close step (verify acceptance criteria against merged state) is the human's, per AGENTS.md.