### PR TITLE
chore(deps): add renovate config for hub slice

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,10 +17,11 @@
     {
       "customType": "regex",
       "description": "Track kbexplorer-template release tags pinned in the showcase workflow",
-      "managerFilePatterns": ["/\\.github\\/workflows\\/showcase\\.yml$/"],
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/showcase\\.yml$/"],
       "matchStrings": [
-        "(?:^|\\r\\n|\\r|\\n)[ \\t]*TEMPLATE_REF:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)[ \\t]*(?:\\r\\n|\\r|\\n|$)"
+        "(?<prefix>(?:^|\\r\\n|\\r|\\n)[ \\t]*)TEMPLATE_REF:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)(?<suffix>[ \\t]*(?:\\r\\n|\\r|\\n|$))"
       ],
+      "autoReplaceStringTemplate": "{{{prefix}}}TEMPLATE_REF: v{{{newValue}}}{{{suffix}}}",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "anokye-labs/kbexplorer-template",
       "versioningTemplate": "semver",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     {
       "groupName": "anokye-labs",
       "matchDatasources": ["npm"],
-      "matchPackagePatterns": ["^@anokye-labs/"]
+      "matchPackageNames": ["@anokye-labs/**"]
     },
     {
       "matchUpdateTypes": ["major"],
@@ -19,7 +19,7 @@
       "description": "Track kbexplorer-template release tags pinned in the showcase workflow",
       "managerFilePatterns": ["/\\.github\\/workflows\\/showcase\\.yml$/"],
       "matchStrings": [
-        "^(?<indent>\\s*)TEMPLATE_REF:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\s*$"
+        "(?:^|\\r\\n|\\r|\\n)[ \\t]*TEMPLATE_REF:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)[ \\t]*(?:\\r\\n|\\r|\\n|$)"
       ],
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "anokye-labs/kbexplorer-template",

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,10 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track kbexplorer-template release tags pinned in the showcase workflow",
       "managerFilePatterns": ["/^\\.github\\/workflows\\/showcase\\.yml$/"],
       "matchStrings": [
-        "(?<prefix>(?:^|\\r\\n|\\r|\\n)[ \\t]*)TEMPLATE_REF:[ \\t]*(?<currentValue>v\\d+\\.\\d+\\.\\d+)(?<suffix>[ \\t]*(?:\\r\\n|\\r|\\n|$))"
+        "(?:^|\\r\\n|\\r|\\n)[ \\t]*TEMPLATE_REF:[ \\t]*v(?<currentValue>\\d+\\.\\d+\\.\\d+)[ \\t]*(?:\\r\\n|\\r|\\n|$)"
       ],
-      "autoReplaceStringTemplate": "{{{prefix}}}TEMPLATE_REF: v{{{newValue}}}{{{suffix}}}",
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "anokye-labs/kbexplorer-template",
       "versioningTemplate": "semver",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "schedule": ["before 6am on Monday"],
+  "packageRules": [
+    {
+      "groupName": "anokye-labs",
+      "matchDatasources": ["npm"],
+      "matchPackagePatterns": ["^@anokye-labs/"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track kbexplorer-template release tags pinned in the showcase workflow",
+      "managerFilePatterns": ["/\\.github\\/workflows\\/showcase\\.yml$/"],
+      "matchStrings": [
+        "^(?<indent>\\s*)TEMPLATE_REF:\\s*(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\s*$"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "anokye-labs/kbexplorer-template",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a repo-level Renovate config with weekly scheduling
- group `@anokye-labs/*` npm dependencies under the `anokye-labs` group
- keep major updates from automerging
- add a regex custom manager for the `TEMPLATE_REF` pin in `.github/workflows/showcase.yml`

refs #133